### PR TITLE
fix hanging issue with xcopy

### DIFF
--- a/basementrenovator/testhook.bat
+++ b/basementrenovator/testhook.bat
@@ -1,3 +1,3 @@
 set out=roomTest.xml
-xcopy /i/y %1 %out%
+xcopy /i/y %1 %out%*
 Executables\XMLToLua.exe %out%


### PR DESCRIPTION
xcopy prompts by default whether it's copying a file or directory if the destination doesn't exist. That means on your first test run xcopy will require console interaction, which leaves everything hanging with no indication. Thought I fixed that, but I didn't. This should do the trick.