### PR TITLE
fix convertstb bug with space in filename

### DIFF
--- a/basementrenovator/convertstb.bat
+++ b/basementrenovator/convertstb.bat
@@ -1,4 +1,3 @@
-set dir=%1\..
-set out=%dir%\%~n1.xml
+set out="%~1\..\%~n1.xml"
 Executables\Gibbed.Afterbirth.ConvertStage.exe %1 %out%
 Executables\XMLToLua.exe %out%


### PR DESCRIPTION
Fixes crash when stb path has spaces in it, e.g. all the afterbirth floors