### PR TITLE
Added Treasure room item price cost when one of the players is Tainted Keeper

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2907,22 +2907,6 @@ do -- RoomsList
                             if shouldSpawnEntity then
                                 local entityData = entityInfo.Data
                                 if doGrids or (entityData.Type > 9 and entityData.Type ~= EntityType.ENTITY_FIREPLACE) then
-									
-									local currentRoom = StageAPI.GetCurrentRoom()
-									local isShopItem = false
-									if currentRoom.RoomType == RoomType.ROOM_TREASURE then
-										if entityData.Type == EntityType.ENTITY_PICKUP and entityData.Variant == PickupVariant.PICKUP_COLLECTIBLE then
-											for i=0, game:GetNumPlayers() - 1 do
-												local player = Isaac.GetPlayer(i)
-												
-												if player:GetPlayerType() == PlayerType.PLAYER_KEEPER_B then
-													isShopItem = true
-													break
-												end
-											end
-										end
-									end
-									
 									local ent = Isaac.Spawn(
                                         entityData.Type or 20,
                                         entityData.Variant or 0,
@@ -2931,16 +2915,27 @@ do -- RoomsList
                                         StageAPI.ZeroVector,
                                         nil
                                     )
-									
-									if isShopItem then
-										ent:ToPickup().Price = 15
-										ent:ToPickup().AutoUpdatePrice = true
-									end
 
+                                    local currentRoom = StageAPI.GetCurrentRoom()
                                     if currentRoom and not currentRoom.IgnoreRoomRules then
                                         if entityData.Type == EntityType.ENTITY_PICKUP and entityData.Variant == PickupVariant.PICKUP_COLLECTIBLE then
-                                            if currentRoom.RoomType == RoomType.ROOM_TREASURE and (currentRoom.Layout.Variant > 0 or string.find(string.lower(currentRoom.Layout.Name), "choice") or string.find(string.lower(currentRoom.Layout.Name), "choose")) then
-                                                ent:ToPickup().OptionsPickupIndex = 1
+                                            if currentRoom.RoomType == RoomType.ROOM_TREASURE then
+                                                if currentRoom.Layout.Variant > 0 or string.find(string.lower(currentRoom.Layout.Name), "choice") or string.find(string.lower(currentRoom.Layout.Name), "choose") then
+                                                    ent:ToPickup().OptionsPickupIndex = 1
+                                                end
+
+                                                local isShopItem
+                                                for _, player in ipairs(players) do
+                                                    if player:GetPlayerType() == PlayerType.PLAYER_KEEPER_B then
+                                                        isShopItem = true
+                                                        break
+                                                    end
+                                                end
+
+                                                if isShopItem then
+                                                    ent:ToPickup().Price = 15
+            										ent:ToPickup().AutoUpdatePrice = true
+                                                end
                                             end
                                         end
                                     end

--- a/main.lua
+++ b/main.lua
@@ -2916,7 +2916,6 @@ do -- RoomsList
 												local player = Isaac.GetPlayer(i)
 												
 												if player:GetPlayerType() == PlayerType.PLAYER_KEEPER_B then
-													entityData.Variant = PickupVariant.PICKUP_SHOPITEM
 													isShopItem = true
 													break
 												end

--- a/main.lua
+++ b/main.lua
@@ -2907,7 +2907,24 @@ do -- RoomsList
                             if shouldSpawnEntity then
                                 local entityData = entityInfo.Data
                                 if doGrids or (entityData.Type > 9 and entityData.Type ~= EntityType.ENTITY_FIREPLACE) then
-                                    local ent = Isaac.Spawn(
+									
+									local currentRoom = StageAPI.GetCurrentRoom()
+									local isShopItem = false
+									if currentRoom.RoomType == RoomType.ROOM_TREASURE then
+										if entityData.Type == EntityType.ENTITY_PICKUP and entityData.Variant == PickupVariant.PICKUP_COLLECTIBLE then
+											for i=0, game:GetNumPlayers() - 1 do
+												local player = Isaac.GetPlayer(i)
+												
+												if player:GetPlayerType() == PlayerType.PLAYER_KEEPER_B then
+													entityData.Variant = PickupVariant.PICKUP_SHOPITEM
+													isShopItem = true
+													break
+												end
+											end
+										end
+									end
+									
+									local ent = Isaac.Spawn(
                                         entityData.Type or 20,
                                         entityData.Variant or 0,
                                         entityData.SubType or 0,
@@ -2915,8 +2932,12 @@ do -- RoomsList
                                         StageAPI.ZeroVector,
                                         nil
                                     )
+									
+									if isShopItem then
+										ent:ToPickup().Price = 15
+										ent:ToPickup().AutoUpdatePrice = true
+									end
 
-                                    local currentRoom = StageAPI.GetCurrentRoom()
                                     if currentRoom and not currentRoom.IgnoreRoomRules then
                                         if entityData.Type == EntityType.ENTITY_PICKUP and entityData.Variant == PickupVariant.PICKUP_COLLECTIBLE then
                                             if currentRoom.RoomType == RoomType.ROOM_TREASURE and (currentRoom.Layout.Variant > 0 or string.find(string.lower(currentRoom.Layout.Name), "choice") or string.find(string.lower(currentRoom.Layout.Name), "choose")) then


### PR DESCRIPTION
Quite some pedestals spawned in through room layouts in special rooms with Tainted Keeper get a price cost assigned, but this wasn't the case in treasure rooms of custom floors. Did seems to already work in other special rooms like devil/angel rooms of custom floors.