### PR TITLE
Increased custom trapdoor disable range

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -8264,7 +8264,7 @@ do -- Transition
         elseif (sprite:IsPlaying("Closed") or sprite:IsFinished("Closed")) and room:IsClear() then
             local playerTooClose
             for _, player in ipairs(players) do
-                local size = (eff.Size + player.Size)
+                local size = (eff.Size + player.Size + 40)
                 if player.Position:DistanceSquared(eff.Position) < size * size then
                     playerTooClose = true
                 end


### PR DESCRIPTION
Increased custom trapdoor disable range for more consistency with vanilla behavior, now custrom trapdoors will stay disabled until the player is at least at a distance equal to (enter range + an extra tile).