### PR TITLE
added PRE_PLAY_MINIBOSS_STREAK callback

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -200,6 +200,10 @@ Callback List:
 
 - CHALLENGE_WAVE_CHANGED()
 
+- PRE_PLAY_MINIBOSS_STREAK(currentRoom, boss, text)
+-- Return false to not play "<player> VS <boss.Name>" as would be
+-- normally done, return a string to use that as the streak text instead
+
 -- StageAPI Structures:
 EntityData {
     Type = integer,
@@ -9541,7 +9545,16 @@ do -- Callbacks
             if not boss.IsMiniboss then
                 StageAPI.PlayBossAnimation(boss)
             else
-                StageAPI.PlayTextStreak(players[1]:GetName() .. " VS " .. boss.Name)
+                local text = players[1]:GetName() .. " VS " .. boss.Name
+                
+                local ret = StageAPI.CallCallbacks("PRE_PLAY_MINIBOSS_STREAK", true, currentRoom, boss, text)
+
+                if ret ~= false then
+                    if ret then
+                        text = ret
+                    end
+                    StageAPI.PlayTextStreak(text)
+                end
             end
         end
 


### PR DESCRIPTION
Added PRE_PLAY_MINIBOSS_STREAK callback to allow disabling/customising VS streaks before minibosses, very specific usecase but no way to do so otherwise