### PR TITLE
Various typo fixes (mostly undefined vars)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ basementrenovator/Executables
 basementrenovator/*.bat
 !basementrenovator/setup.bat
 basementrenovator/*.py
+.vscode/settings.json

--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -588,8 +588,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 
     if StageAPI.TransitioningToExtraRoom and StageAPI.IsRoomTopLeftShifted() and not StageAPI.DoubleTransitioning then
         StageAPI.DoubleTransitioning = true
-        -- extraRoom used but not set: what was it intended to do?
-        local defaultGridRoom, alternateGridRoom, defaultLargeGridRoom, alternateLargeGridRoom = StageAPI.GetExtraRoomBaseGridRooms(extraRoomBaseType == RoomType.ROOM_BOSS)
+        local defaultGridRoom, alternateGridRoom, defaultLargeGridRoom, alternateLargeGridRoom = StageAPI.GetExtraRoomBaseGridRooms(shared.Room:GetType() == RoomType.ROOM_BOSS)
         local targetRoom
         if shared.Level:GetCurrentRoomIndex() == defaultGridRoom then
             targetRoom = alternateGridRoom

--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -588,6 +588,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 
     if StageAPI.TransitioningToExtraRoom and StageAPI.IsRoomTopLeftShifted() and not StageAPI.DoubleTransitioning then
         StageAPI.DoubleTransitioning = true
+        -- extraRoom used but not set: what was it intended to do?
         local defaultGridRoom, alternateGridRoom, defaultLargeGridRoom, alternateLargeGridRoom = StageAPI.GetExtraRoomBaseGridRooms(extraRoomBaseType == RoomType.ROOM_BOSS)
         local targetRoom
         if shared.Level:GetCurrentRoomIndex() == defaultGridRoom then
@@ -642,15 +643,15 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
                     if not (levelRoom and levelRoom.IsPersistentRoom) then
                         StageAPI.SetLevelRoom(nil, roomId, dimension)
                     else
-                        maintainGrids[dimension][index] = true
+                        maintainGrids[dimension][roomId] = true
                     end
                 end
             end
 
             for dimension, roomCustomGrids in pairs(StageAPI.CustomGrids) do
-                for index, grids in pairs(roomCustomGrids) do
-                    if not maintainGrids[dimension] or not maintainGrids[dimension][index] then
-                        roomCustomGrids[index] = nil
+                for roomId, grids in pairs(roomCustomGrids) do
+                    if not maintainGrids[dimension] or not maintainGrids[dimension][roomId] then
+                        roomCustomGrids[roomId] = nil
                     end
                 end
             end
@@ -874,7 +875,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 end)
 
 function StageAPI.GetGridPosition(index, width)
-    local x, y = StageAPI.GridToVector(i, width)
+    local x, y = StageAPI.GridToVector(index, width)
     y = y + 4
     x = x + 2
     return x * 40, y * 40

--- a/scripts/stageapi/grid/customgrids.lua
+++ b/scripts/stageapi/grid/customgrids.lua
@@ -50,6 +50,7 @@ StageAPI.DefaultBrokenGridStateByType = {
     [GridEntityType.GRID_POOP]      = 1000,
 }
 
+-- { [dimension] = { [roomId] = { Grids = { [gridPersistIdx] = <grid data> }, LastPersistentIndex = N } } }
 StageAPI.CustomGrids = {}
 function StageAPI.GetRoomCustomGrids(dimension, roomID)
     local customGrids = StageAPI.GetTableIndexedByDimensionRoom(StageAPI.CustomGrids, true, dimension, roomID)

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -75,7 +75,7 @@ function StageAPI.LevelRoom:Init(args, ...)
         self:PostGetLayout(self.SpawnSeed)
     end
 
-    StageAPI.CallCallbacks("POST_ROOM_INIT", false, self, not not fromSaveData, fromSaveData)
+    StageAPI.CallCallbacks("POST_ROOM_INIT", false, self, not not args.FromSave, args.FromSave)
     StageAPI.CurrentlyInitializing = nil
 end
 
@@ -166,7 +166,7 @@ function StageAPI.LevelRoom:PostGetLayout(seed)
     end
 
     StageAPI.LogMinor("Initialized room " .. self.Layout.Name .. "." .. tostring(self.Layout.Variant) .. " from file " .. tostring(self.Layout.RoomFilename)
-                        .. (roomsList and (' from list ' .. roomsList.Name) or ''))
+                        .. (self.RoomsListName and (' from list ' .. self.RoomsListName) or ''))
 
     if self.Shape == -1 then
         self.Shape = self.Layout.Shape
@@ -483,7 +483,7 @@ function StageAPI.LevelRoom:LoadSaveData(saveData)
     end
 
     if saveData.PersistenceData then
-        for pindex, persistData in pairs(saveData.PersistenceData) do
+        for strindex, persistData in pairs(saveData.PersistenceData) do
             self.PersistenceData[tonumber(strindex)] = persistData
         end
     end

--- a/scripts/stageapi/stage/bosses.lua
+++ b/scripts/stageapi/stage/bosses.lua
@@ -265,7 +265,7 @@ StageAPI.PlayingBossSpriteDirt = nil
 StageAPI.UnskippableBossAnim = nil
 StageAPI.BossOffset = nil
 
-function StageAPI.PlayBossAnimationManual(portrait, name, spot, playerPortrait, playerName, playerSpot, portraitTwo, unskippable, bgColor, dirtColor, noSkake)
+function StageAPI.PlayBossAnimationManual(portrait, name, spot, playerPortrait, playerName, playerSpot, portraitTwo, unskippable, bgColor, dirtColor, noShake)
     local paramTable = portrait
     if type(paramTable) ~= "table" then
         paramTable = {

--- a/scripts/stageapi/stage/customFloorGen.lua
+++ b/scripts/stageapi/stage/customFloorGen.lua
@@ -607,7 +607,7 @@ function StageAPI.GetRoomMapSegments(roomX, roomY, shape)
     return onMap
 end
 
-function StageAPI.GetMapSegmentsFromRoomObject(roomObject, noCaching)
+function StageAPI.GetMapSegmentsFromRoomObject(roomObject, noCaching, noInterference)
     local typ = type(roomObject)
     if typ == "table" then
         if roomObject.MapSegments then

--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -327,6 +327,7 @@ function StageAPI.CustomStage:GetPlayingMusic()
         if self.BossMusic then
             local music = self.BossMusic
             local musicID, queue, disregardNonOverride
+            local isCleared = shared.Room:GetAliveBossesCount() < 1 or shared.Room:IsClear()
 
             if (music.Outro and (id == Music.MUSIC_JINGLE_BOSS_OVER or id == Music.MUSIC_JINGLE_BOSS_OVER2 or id == music.Outro or (type(music.Outro) == "table" and StageAPI.IsIn(music.Outro, id))))
             or (music.Intro and (id == Music.MUSIC_JINGLE_BOSS or id == music.Intro or (type(music.Intro) == "table" and StageAPI.IsIn(music.Intro, id)))) then
@@ -338,7 +339,6 @@ function StageAPI.CustomStage:GetPlayingMusic()
 
                 disregardNonOverride = true
             else
-                local isCleared = shared.Room:GetAliveBossesCount() < 1 or shared.Room:IsClear()
                 if isCleared then
                     musicID = music.Cleared
                 else

--- a/scripts/stageapi/stage/roomgfx.lua
+++ b/scripts/stageapi/stage/roomgfx.lua
@@ -3,6 +3,8 @@ local shared = require("scripts.stageapi.shared")
 StageAPI.LogMinor("Loading Backdrop & RoomGfx Handling")
 
 StageAPI.BackdropRNG = RNG()
+
+-- These two are unused, remove or unintended?
 local backdropDefaultOffset = Vector(260,0)
 local backdropIvOffset = Vector(113,0)
 
@@ -73,7 +75,7 @@ function StageAPI.LoadBackdropSprite(sprite, backdrop, mode) -- modes are 1 (wal
         local corners
         local walls
         if backdrop.WallVariants then
-            walls = backdrop.WallVariants[StageAPI.Random(1, #backdrop.WallVariants, backdropRNG)]
+            walls = backdrop.WallVariants[StageAPI.Random(1, #backdrop.WallVariants, StageAPI.BackdropRNG)]
             corners = walls.Corners or backdrop.Corners
         else
             walls = backdrop.Walls
@@ -82,13 +84,13 @@ function StageAPI.LoadBackdropSprite(sprite, backdrop, mode) -- modes are 1 (wal
 
         if walls then
             for num = 1, StageAPI.ShapeToWallAnm2Layers[shapeName] do
-                local wall_to_use = walls[StageAPI.Random(1, #walls, backdropRNG)]
+                local wall_to_use = walls[StageAPI.Random(1, #walls, StageAPI.BackdropRNG)]
                 sprite:ReplaceSpritesheet(num, wall_to_use)
             end
         end
 
         if corners and string.sub(shapeName, 1, 1) == "L" then
-            local corner_to_use = corners[StageAPI.Random(1, #corners, backdropRNG)]
+            local corner_to_use = corners[StageAPI.Random(1, #corners, StageAPI.BackdropRNG)]
             sprite:ReplaceSpritesheet(0, corner_to_use)
         end
     elseif mode == 2 then
@@ -100,7 +102,7 @@ function StageAPI.LoadBackdropSprite(sprite, backdrop, mode) -- modes are 1 (wal
 
         local floors
         if backdrop.FloorVariants then
-            floors = backdrop.FloorVariants[StageAPI.Random(1, #backdrop.FloorVariants, backdropRNG)]
+            floors = backdrop.FloorVariants[StageAPI.Random(1, #backdrop.FloorVariants, StageAPI.BackdropRNG)]
         else
             floors = backdrop.Floors or backdrop.Walls
         end
@@ -117,20 +119,20 @@ function StageAPI.LoadBackdropSprite(sprite, backdrop, mode) -- modes are 1 (wal
 
             if numFloors then
                 for i = 0, numFloors - 1 do
-                    sprite:ReplaceSpritesheet(i, floors[StageAPI.Random(1, #floors, backdropRNG)])
+                    sprite:ReplaceSpritesheet(i, floors[StageAPI.Random(1, #floors, StageAPI.BackdropRNG)])
                 end
             end
         end
 
         if backdrop.NFloors and string.sub(shapeName, 1, 1) == "I" then
             for num = 18, 19 do
-                sprite:ReplaceSpritesheet(num, backdrop.NFloors[StageAPI.Random(1, #backdrop.NFloors, backdropRNG)])
+                sprite:ReplaceSpritesheet(num, backdrop.NFloors[StageAPI.Random(1, #backdrop.NFloors, StageAPI.BackdropRNG)])
             end
         end
 
         if backdrop.LFloors and string.sub(shapeName, 1, 1) == "L" then
             for num = 16, 17 do
-                sprite:ReplaceSpritesheet(num, backdrop.LFloors[StageAPI.Random(1, #backdrop.LFloors, backdropRNG)])
+                sprite:ReplaceSpritesheet(num, backdrop.LFloors[StageAPI.Random(1, #backdrop.LFloors, StageAPI.BackdropRNG)])
             end
         end
     end

--- a/scripts/stageapi/stage/roomgfx.lua
+++ b/scripts/stageapi/stage/roomgfx.lua
@@ -4,10 +4,6 @@ StageAPI.LogMinor("Loading Backdrop & RoomGfx Handling")
 
 StageAPI.BackdropRNG = RNG()
 
--- These two are unused, remove or unintended?
-local backdropDefaultOffset = Vector(260,0)
-local backdropIvOffset = Vector(113,0)
-
 StageAPI.ShapeToWallAnm2Layers = {
     ["1x2"] = 58,
     ["2x2"] = 63,


### PR DESCRIPTION
Fixed various typos that used undefined vars in some parts of code, the one in save loading might have had more reaching consequences? Or just minor, idk

Some doubts left:

## Unsolved issues (missing knowledge):
[callbacks.lua](https://github.com/Meowlala/BOIStageAPI15/blob/dbc163ca837fc6acbed31ceef7b0306f06993d22/scripts/stageapi/core/callbacks.lua):
* line 591: uses extraRoomBaseType but that is not defined here, what was that meant to do?

## Doubts:
[customFloorGen.lua](https://github.com/Meowlala/BOIStageAPI15/blob/dbc163ca837fc6acbed31ceef7b0306f06993d22/scripts/stageapi/stage/customFloorGen.lua):
* line 617: noInterference not defined, was that supposed to be an arg? Assumed so and added it

