### PR TITLE
Callback library improvement

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -226,7 +226,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     end
 
     if gridCount ~= StageAPI.PreviousGridCount then
-        local gridCallbacks = StageAPI.CallCallbacks(Callbacks.POST_GRID_UPDATE)
+        StageAPI.CallCallbacks(Callbacks.POST_GRID_UPDATE)
 
         updatedGrids = true
         local roomGrids = StageAPI.GetTableIndexedByDimension(StageAPI.RoomGrids, true)

--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -346,7 +346,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         -- is the second arg, won't change for backwards compat
         local callbacks = StageAPI.GetCallbacks(Callbacks.PRE_CHANGE_ROOM_GFX)
         for _, callback in ipairs(callbacks) do
-            local success, ret = StageAPI.TryCallback(Callbacks.PRE_CHANGE_ROOM_GFX, callback, currentRoom, usingGfx, true)
+            local success, ret = StageAPI.TryCallback(callback, currentRoom, usingGfx, true)
             if success and ret ~= nil then
                 usingGfx = ret
             end
@@ -895,7 +895,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
     -- is the second arg, won't change for backwards compat
     local callbacks = StageAPI.GetCallbacks(Callbacks.PRE_CHANGE_ROOM_GFX)
     for _, callback in ipairs(callbacks) do
-        local success, ret = StageAPI.TryCallback(Callbacks.PRE_CHANGE_ROOM_GFX, callback, currentRoom, usingGfx, false)
+        local success, ret = StageAPI.TryCallback(callback, currentRoom, usingGfx, false)
         if success and ret ~= nil then
             usingGfx = ret
         end

--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -342,10 +342,12 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     if StageAPI.LastBackdropType ~= backdropType then
         local currentRoom = StageAPI.GetCurrentRoom()
         local usingGfx
+        -- Manual handling instead of CallCallbacksAccumulator needed as usingGfx 
+        -- is the second arg, won't change for backwards compat
         local callbacks = StageAPI.GetCallbacks(Callbacks.PRE_CHANGE_ROOM_GFX)
         for _, callback in ipairs(callbacks) do
-            local ret = callback.Function(currentRoom, usingGfx, true)
-            if ret ~= nil then
+            local success, ret = StageAPI.TryCallback(Callbacks.PRE_CHANGE_ROOM_GFX, callback, currentRoom, usingGfx, true)
+            if success and ret ~= nil then
                 usingGfx = ret
             end
         end
@@ -889,10 +891,12 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
         usingGfx = StageAPI.CurrentStage.RoomGfx[rtype]
     end
 
+    -- Manual handling instead of CallCallbacksAccumulator needed as usingGfx 
+    -- is the second arg, won't change for backwards compat
     local callbacks = StageAPI.GetCallbacks(Callbacks.PRE_CHANGE_ROOM_GFX)
     for _, callback in ipairs(callbacks) do
-        local ret = callback.Function(currentRoom, usingGfx, false)
-        if ret ~= nil then
+        local success, ret = StageAPI.TryCallback(Callbacks.PRE_CHANGE_ROOM_GFX, callback, currentRoom, usingGfx, false)
+        if success and ret ~= nil then
             usingGfx = ret
         end
     end

--- a/scripts/stageapi/grid/customdoors.lua
+++ b/scripts/stageapi/grid/customdoors.lua
@@ -242,12 +242,10 @@ StageAPI.AddCallback("StageAPI", Callbacks.POST_SPAWN_CUSTOM_GRID, 0, function(c
     data.DoorData = doorData
     data.Opened = opened
 
-    local callbacks = StageAPI.GetCallbacks(Callbacks.POST_SPAWN_CUSTOM_DOOR)
-    for _, callback in ipairs(callbacks) do
-        if not callback.Params[1] or callback.Params[1] == persistData.DoorDataName then
-            callback.Function(door, data, sprite, doorData, customGrid, force, respawning)
-        end
-    end
+    StageAPI.CallCallbacksWithParams(
+        Callbacks.POST_SPAWN_CUSTOM_DOOR, false, persistData.DoorDataName, 
+        door, data, sprite, doorData, customGrid, force, respawning
+    )
 end, "CustomDoor")
 
 mod:AddCallback(ModCallbacks.MC_POST_EFFECT_RENDER, function(_, door)
@@ -572,12 +570,10 @@ mod:AddCallback(ModCallbacks.MC_POST_EFFECT_UPDATE, function(_, door)
         end
     end
 
-    local callbacks = StageAPI.GetCallbacks(Callbacks.POST_CUSTOM_DOOR_UPDATE)
-    for _, callback in ipairs(callbacks) do
-        if not callback.Params[1] or callback.Params[1] == data.DoorGridData.DoorDataName then
-            callback.Function(door, data, sprite, doorData, data.DoorGridData)
-        end
-    end
+    StageAPI.CallCallbacksWithParams(
+        Callbacks.POST_CUSTOM_DOOR_UPDATE, false, data.DoorGridData.DoorDataName, 
+        door, data, sprite, doorData, data.DoorGridData
+    )
 end, StageAPI.E.Door.V)
 
 mod:AddCallback(ModCallbacks.MC_POST_UPDATE, function()

--- a/scripts/stageapi/grid/customgrids.lua
+++ b/scripts/stageapi/grid/customgrids.lua
@@ -338,11 +338,7 @@ function StageAPI.CustomGridEntity:Remove(keepBaseGrid)
 end
 
 function StageAPI.CustomGridEntity:CallCallbacks(callback, ...)
-    for _, callback in ipairs(StageAPI.GetCallbacks(callback)) do
-        if not callback.Params[1] or callback.Params[1] == self.GridConfig.Name then
-            callback.Function(self, ...)
-        end
-    end
+    StageAPI.CallCallbacksWithParams(callback, false, self.GridConfig.Name, self, ...)
 end
 
 function StageAPI.GetCustomGrids(index, name)

--- a/scripts/stageapi/library/callbacks.lua
+++ b/scripts/stageapi/library/callbacks.lua
@@ -208,6 +208,51 @@ function StageAPI.TryCallbackParams(callback, params, ...)
     end
 end
 
+---Separate function as table packing/unpacking 
+---would be slower for generic-purpose calls (that
+---might be made for each room entitiy, multiple times, 
+---etc.); difference not too big, but might as well
+---@param callback StageAPICallback
+---@return boolean, any, ... # returns success, return value of callback
+function StageAPI.TryCallbackMultiReturn(callback, ...)
+    local rets = {pcall(callback.Function, ...)}
+    local success = rets[1]
+    if success then
+        return true, table.unpack(rets, 2)
+    else
+        StageAPI.LogErr(("[Callback: %s]"):format(tostring(callback.CallbackID)), rets[2])
+        return false
+    end
+end
+
+---Separate function as table packing/unpacking 
+---would be slower for generic-purpose calls (that
+---might be made for each room entitiy, multiple times, 
+---etc.); difference not too big, but might as well
+---@param callback StageAPICallback
+---@param params any
+---@return boolean, any, ... # returns success, return value of callback
+function StageAPI.TryCallbackMultiReturnParams(callback, params, ...)
+    local rets = {pcall(callback.Function, ...)}
+    local success = rets[1]
+    if success then
+        return true, table.unpack(rets, 2)
+    else
+        local paramString
+        if type(params) == "table" then
+            local stringParams = {}
+            for i, param in ipairs(params) do
+                stringParams[i] = tostring(param)
+            end
+            paramString = table.concat(stringParams, ", ")
+        else
+            paramString = tostring(params)
+        end
+        StageAPI.LogErr(("[Callback: %s <%s>]"):format(tostring(callback.CallbackID), paramString), rets[2])
+        return false
+    end
+end
+
 
 local TEST = false
 

--- a/scripts/stageapi/library/callbacks.lua
+++ b/scripts/stageapi/library/callbacks.lua
@@ -77,8 +77,8 @@ end
 function StageAPI.CallCallbacks(id, breakOnFirstReturn, ...)
     local finalRet
     for _, callback in ipairs(StageAPI.GetCallbacks(id)) do
-        local ret = StageAPI.TryCallback(id, callback, ...)
-        if ret ~= nil then
+        local success, ret = StageAPI.TryCallback(id, callback, ...)
+        if success and ret ~= nil then
             if breakOnFirstReturn then
                 return ret
             end
@@ -114,8 +114,8 @@ function StageAPI.CallCallbacksWithParams(id, breakOnFirstReturn, matchParams, .
     local callbacks = StageAPI.GetCallbacks(id)
     for _, callback in ipairs(callbacks) do
         if MatchesParams(callback, matchParams) then
-            local ret = StageAPI.TryCallbackParams(id, callback, matchParams, ...)
-            if ret ~= nil then
+            local success, ret = StageAPI.TryCallbackParams(id, callback, matchParams, ...)
+            if success and ret ~= nil then
                 if breakOnFirstReturn then
                     return ret
                 end
@@ -137,8 +137,8 @@ end
 function StageAPI.CallCallbacksAccumulator(id, startValue, ...)
     local finalRet = startValue
     for _, callback in ipairs(StageAPI.GetCallbacks(id)) do
-        local ret = StageAPI.TryCallback(id, callback, finalRet, ...)
-        if ret ~= nil then
+        local success, ret = StageAPI.TryCallback(id, callback, finalRet, ...)
+        if success and ret ~= nil then
             finalRet = ret
         end
     end
@@ -162,8 +162,8 @@ function StageAPI.CallCallbacksAccumulatorParams(id, matchParams, startValue, ..
     local finalRet = startValue
     for _, callback in ipairs(StageAPI.GetCallbacks(id)) do
         if MatchesParams(callback, matchParams) then
-            local ret = StageAPI.TryCallbackParams(id, callback, matchParams, finalRet, ...)
-            if ret ~= nil then
+            local success, ret = StageAPI.TryCallbackParams(id, callback, matchParams, finalRet, ...)
+            if success and ret ~= nil then
                 finalRet = ret
             end
         end
@@ -173,22 +173,25 @@ end
 
 ---@param id callbackId
 ---@param callback StageAPICallback
+---@return boolean, any # returns success, return value of callback
 function StageAPI.TryCallback(id, callback, ...)
     local success, ret = pcall(callback.Function, ...)
     if success then
-        return ret
+        return true, ret
     else
         StageAPI.LogErr(("[Callback: %s]"):format(tostring(id)), ret)
+        return false
     end
 end
 
 ---@param id callbackId
 ---@param callback StageAPICallback
 ---@param params any
+---@return boolean, any # returns success, return value of callback
 function StageAPI.TryCallbackParams(id, callback, params, ...)
     local success, ret = pcall(callback.Function, ...)
     if success then
-        return ret
+        return true, ret
     else
         local paramString
         if type(params) == "table" then
@@ -201,6 +204,7 @@ function StageAPI.TryCallbackParams(id, callback, params, ...)
             paramString = tostring(params)
         end
         StageAPI.LogErr(("[Callback: %s <%s>]"):format(tostring(id), paramString), ret)
+        return false
     end
 end
 

--- a/scripts/stageapi/room/roomHandler.lua
+++ b/scripts/stageapi/room/roomHandler.lua
@@ -307,9 +307,7 @@ function StageAPI.SelectSpawnEntities(entities, seed, roomMetadata, lastPersiste
             local addEntities = {}
             local overridden, stillAddRandom = false, nil
             for _, callback in ipairs(callbacks) do
-                -- Manualest handling, to make multiple returns still work
-                -- TODO: change TryCallback to have multiple returns work
-                local success, retAdd, retList, retRandom = pcall(callback.Function, entityList, index, roomMetadata)
+                local success, retAdd, retList, retRandom = StageAPI.TryCallbackMultiReturn(callback, entityList, index, roomMetadata)
                 if success then
                     if retRandom ~= nil and stillAddRandom == nil then
                         stillAddRandom = retRandom
@@ -332,8 +330,6 @@ function StageAPI.SelectSpawnEntities(entities, seed, roomMetadata, lastPersiste
                     if overridden then
                         break
                     end
-                else
-                    StageAPI.LogErr("PRE_SELECT_ENTITY_LIST error: " .. retAdd)
                 end
             end
 
@@ -505,7 +501,8 @@ function StageAPI.LoadEntitiesFromEntitySets(entitysets, doGrids, doPersistentOn
                             and not callback.Params[2] or (entityInfo.Data.Variant and callback.Params[2] == entityInfo.Data.Variant)
                             and not callback.Params[3] or (entityInfo.Data.SubType and callback.Params[3] == entityInfo.Data.SubType) then
                                 local success, ret = StageAPI.TryCallback(callback,
-                                    entityInfo, entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData, shouldSpawnEntity)
+                                    entityInfo, entityList, index, doGrids, doPersistentOnly, 
+                                    doAutoPersistent, avoidSpawning, persistenceData, shouldSpawnEntity)
                                 if success then
                                     if ret == false or ret == true then
                                         shouldSpawnEntity = ret

--- a/scripts/stageapi/room/roomHandler.lua
+++ b/scripts/stageapi/room/roomHandler.lua
@@ -189,7 +189,7 @@ function StageAPI.GetValidRoomsForLayout(args)
         local weight = layout.Weight
         if isValid then
             for _, callback in ipairs(callbacks) do
-                local success, ret = StageAPI.TryCallback(Callbacks.POST_CHECK_VALID_ROOM, callback, 
+                local success, ret = StageAPI.TryCallback(callback, 
                         layout, roomList, seed, shape, rtype, requireRoomType)
                 if success then
                     if ret == false then
@@ -365,7 +365,7 @@ function StageAPI.SelectSpawnGrids(gridsByIndex, seed)
         if #grids > 0 then
             local spawnGrid, noSpawnGrid
             for _, callback in ipairs(callbacks) do
-                local success, ret = StageAPI.TryCallback(Callbacks.PRE_SELECT_GRIDENTITY_LIST, callback, grids, index)
+                local success, ret = StageAPI.TryCallback(callback, grids, index)
                 if success then
                     if ret == false then
                         noSpawnGrid = true
@@ -448,7 +448,7 @@ function StageAPI.LoadEntitiesFromEntitySets(entitysets, doGrids, doPersistentOn
             if #entityList > 0 then
                 local shouldSpawn = true
                 for _, callback in ipairs(listCallbacks) do
-                    local success, ret = StageAPI.TryCallback(Callbacks.PRE_SPAWN_ENTITY_LIST, callback,
+                    local success, ret = StageAPI.TryCallback(callback,
                         entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData)
                     if success then
                         if ret == false then
@@ -504,7 +504,7 @@ function StageAPI.LoadEntitiesFromEntitySets(entitysets, doGrids, doPersistentOn
                             if not callback.Params[1] or (entityInfo.Data.Type and callback.Params[1] == entityInfo.Data.Type)
                             and not callback.Params[2] or (entityInfo.Data.Variant and callback.Params[2] == entityInfo.Data.Variant)
                             and not callback.Params[3] or (entityInfo.Data.SubType and callback.Params[3] == entityInfo.Data.SubType) then
-                                local success, ret = StageAPI.TryCallback(Callbacks.PRE_SPAWN_ENTITY, callback,
+                                local success, ret = StageAPI.TryCallback(callback,
                                     entityInfo, entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData, shouldSpawnEntity)
                                 if success then
                                     if ret == false or ret == true then
@@ -613,7 +613,7 @@ function StageAPI.LoadGridsFromDataList(grids, gridInformation, entities)
     for index, gridData in pairs(iterList) do
         local shouldSpawn = true
         for _, callback in ipairs(callbacks) do
-            local success, ret = StageAPI.TryCallback(Callbacks.PRE_SPAWN_GRID, callback, 
+            local success, ret = StageAPI.TryCallback(callback, 
                 gridData, gridInformation, entities, StageAPI.GridSpawnRNG)
             if success then
                 if ret == false then

--- a/scripts/stageapi/room/roomHandler.lua
+++ b/scripts/stageapi/room/roomHandler.lua
@@ -185,16 +185,19 @@ function StageAPI.GetValidRoomsForLayout(args)
                 end
             end
         end
-
+    
         local weight = layout.Weight
         if isValid then
             for _, callback in ipairs(callbacks) do
-                local ret = callback.Function(layout, roomList, seed, shape, rtype, requireRoomType)
-                if ret == false then
-                    isValid = false
-                    break
-                elseif type(ret) == "number" then
-                    weight = ret
+                local success, ret = StageAPI.TryCallback(Callbacks.POST_CHECK_VALID_ROOM, callback, 
+                        layout, roomList, seed, shape, rtype, requireRoomType)
+                if success then
+                    if ret == false then
+                        isValid = false
+                        break
+                    elseif type(ret) == "number" then
+                        weight = ret
+                    end
                 end
             end
         end
@@ -304,27 +307,33 @@ function StageAPI.SelectSpawnEntities(entities, seed, roomMetadata, lastPersiste
             local addEntities = {}
             local overridden, stillAddRandom = false, nil
             for _, callback in ipairs(callbacks) do
-                local retAdd, retList, retRandom = callback.Function(entityList, index, roomMetadata)
-                if retRandom ~= nil and stillAddRandom == nil then
-                    stillAddRandom = retRandom
-                end
+                -- Manualest handling, to make multiple returns still work
+                -- TODO: change TryCallback to have multiple returns work
+                local success, retAdd, retList, retRandom = pcall(callback.Function, entityList, index, roomMetadata)
+                if success then
+                    if retRandom ~= nil and stillAddRandom == nil then
+                        stillAddRandom = retRandom
+                    end
 
-                if retAdd == false then
-                    overridden = true
+                    if retAdd == false then
+                        overridden = true
+                    else
+                        if retAdd and type(retAdd) == "table" then
+                            addEntities = retAdd
+                            overridden = true
+                        end
+
+                        if retList and type(retList) == "table" then
+                            entityList = retList
+                            overridden = true
+                        end
+                    end
+
+                    if overridden then
+                        break
+                    end
                 else
-                    if retAdd and type(retAdd) == "table" then
-                        addEntities = retAdd
-                        overridden = true
-                    end
-
-                    if retList and type(retList) == "table" then
-                        entityList = retList
-                        overridden = true
-                    end
-                end
-
-                if overridden then
-                    break
+                    StageAPI.LogErr("PRE_SELECT_ENTITY_LIST error: " .. retAdd)
                 end
             end
 
@@ -356,18 +365,20 @@ function StageAPI.SelectSpawnGrids(gridsByIndex, seed)
         if #grids > 0 then
             local spawnGrid, noSpawnGrid
             for _, callback in ipairs(callbacks) do
-                local ret = callback.Function(grids, index)
-                if ret == false then
-                    noSpawnGrid = true
-                    break
-                elseif type(ret) == "table" then
-                    if ret.Index then
-                        spawnGrid = ret
-                    else
-                        grids = ret
-                    end
+                local success, ret = StageAPI.TryCallback(Callbacks.PRE_SELECT_GRIDENTITY_LIST, callback, grids, index)
+                if success then
+                    if ret == false then
+                        noSpawnGrid = true
+                        break
+                    elseif type(ret) == "table" then
+                        if ret.Index then
+                            spawnGrid = ret
+                        else
+                            grids = ret
+                        end
 
-                    break
+                        break
+                    end
                 end
             end
 
@@ -437,13 +448,16 @@ function StageAPI.LoadEntitiesFromEntitySets(entitysets, doGrids, doPersistentOn
             if #entityList > 0 then
                 local shouldSpawn = true
                 for _, callback in ipairs(listCallbacks) do
-                    local ret = callback.Function(entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData)
-                    if ret == false then
-                        shouldSpawn = false
-                        break
-                    elseif ret and type(ret) == "table" then
-                        entityList = ret
-                        break
+                    local success, ret = StageAPI.TryCallback(Callbacks.PRE_SPAWN_ENTITY_LIST, callback,
+                        entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData)
+                    if success then
+                        if ret == false then
+                            shouldSpawn = false
+                            break
+                        elseif ret and type(ret) == "table" then
+                            entityList = ret
+                            break
+                        end
                     end
                 end
 
@@ -490,19 +504,22 @@ function StageAPI.LoadEntitiesFromEntitySets(entitysets, doGrids, doPersistentOn
                             if not callback.Params[1] or (entityInfo.Data.Type and callback.Params[1] == entityInfo.Data.Type)
                             and not callback.Params[2] or (entityInfo.Data.Variant and callback.Params[2] == entityInfo.Data.Variant)
                             and not callback.Params[3] or (entityInfo.Data.SubType and callback.Params[3] == entityInfo.Data.SubType) then
-                                local ret = callback.Function(entityInfo, entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData, shouldSpawnEntity)
-                                if ret == false or ret == true then
-                                    shouldSpawnEntity = ret
-                                    break
-                                elseif ret and type(ret) == "table" then
-                                    if ret.Data then
-                                        entityInfo = ret
-                                    else
-                                        entityInfo.Data.Type = ret[1] == 999 and 1000 or ret[1]
-                                        entityInfo.Data.Variant = ret[2]
-                                        entityInfo.Data.SubType = ret[3]
+                                local success, ret = StageAPI.TryCallback(Callbacks.PRE_SPAWN_ENTITY, callback,
+                                    entityInfo, entityList, index, doGrids, doPersistentOnly, doAutoPersistent, avoidSpawning, persistenceData, shouldSpawnEntity)
+                                if success then
+                                    if ret == false or ret == true then
+                                        shouldSpawnEntity = ret
+                                        break
+                                    elseif ret and type(ret) == "table" then
+                                        if ret.Data then
+                                            entityInfo = ret
+                                        else
+                                            entityInfo.Data.Type = ret[1] == 999 and 1000 or ret[1]
+                                            entityInfo.Data.Variant = ret[2]
+                                            entityInfo.Data.SubType = ret[3]
+                                        end
+                                        break
                                     end
-                                    break
                                 end
                             end
                         end
@@ -596,12 +613,15 @@ function StageAPI.LoadGridsFromDataList(grids, gridInformation, entities)
     for index, gridData in pairs(iterList) do
         local shouldSpawn = true
         for _, callback in ipairs(callbacks) do
-            local ret = callback.Function(gridData, gridInformation, entities, StageAPI.GridSpawnRNG)
-            if ret == false then
-                shouldSpawn = false
-                break
-            elseif type(ret) == "table" then
-                gridData = ret
+            local success, ret = StageAPI.TryCallback(Callbacks.PRE_SPAWN_GRID, callback, 
+                gridData, gridInformation, entities, StageAPI.GridSpawnRNG)
+            if success then
+                if ret == false then
+                    shouldSpawn = false
+                    break
+                elseif type(ret) == "table" then
+                    gridData = ret
+                end
             end
         end
 


### PR DESCRIPTION
Main change: callbacks now check for errors on each callback call, and if an error happens won't stop the whole call stack but just the specific callback, and print the error.
This should improve bug reporting for dependent mods.

Also, more functions added to allow easier calling through the library, documented in [doc.md](https://github.com/Meowlala/BOIStageAPI15/pull/43/files#diff-07d30049577ad63d59568f238f9698d1254a2d1110e1a755b2f6b17ee2570c25). Mainly caling with filtering params specified, and calling with an accumulator.