### PR TITLE
stageapi class autocomplete with emmylua

### DIFF
--- a/scripts/stageapi/grid/customdoors.lua
+++ b/scripts/stageapi/grid/customdoors.lua
@@ -36,6 +36,23 @@ end
 StageAPI.CustomDoorGrid = StageAPI.CustomGrid("CustomDoor")
 
 StageAPI.DoorTypes = {}
+
+---@param name any
+---@param anm2? string
+---@param openAnim? string
+---@param closeAnim? string
+---@param openedAnim? string
+---@param closedAnim? string
+---@param noAutoHandling? boolean
+---@param alwaysOpen? boolean
+---@param exitFunction? fun(door: EntityEffect, data: table, sprite: Sprite, doorData: CustomDoor, doorGridData: table) #doorGridData is the persistData
+---@param directionOffsets? table<Direction, Vector>
+---@param transitionAnim? integer Transition anim ID
+---@return CustomDoor
+function StageAPI.CustomDoor(name, anm2, openAnim, closeAnim, openedAnim, closedAnim, noAutoHandling, alwaysOpen, exitFunction, directionOffsets, transitionAnim)
+end
+
+---@class CustomDoor : StageAPIClass
 StageAPI.CustomDoor = StageAPI.Class("CustomDoor")
 function StageAPI.CustomDoor:Init(name, anm2, openAnim, closeAnim, openedAnim, closedAnim, noAutoHandling, alwaysOpen, exitFunction, directionOffsets, transitionAnim)
     self.NoAutoHandling = noAutoHandling
@@ -52,6 +69,68 @@ function StageAPI.CustomDoor:Init(name, anm2, openAnim, closeAnim, openedAnim, c
     StageAPI.DoorTypes[name] = self
 end
 
+---@param name string
+---@param anm2? string
+---@param states table<string, CustomStateDoor_StateData | string>
+---@param exitFunction? fun(door: EntityEffect, data: table, sprite: Sprite, doorData: CustomDoor, doorGridData: table) #doorGridData is the persistData
+---@param overlayAnm2? string optional, uses a separate sprite rather than an overlay anim for overlay animations
+---@param directionOffsets? table<Direction, Vector>
+---@return CustomStateDoor
+function StageAPI.CustomStateDoor(name, anm2, states, exitFunction, overlayAnm2, directionOffsets)
+end
+
+---@class CustomStateDoor_StateData
+---@field Anim string
+---@field OverlayAnim string
+---@field Frame integer
+---@field OverlayFrame integer
+---@field PlayAtStart boolean
+---@field Passable boolean
+---@field ChangeAfterTriggerAnim boolean
+---@field NoMemory boolean
+---@field RememberAs string state name to be saved in persistData instead of state name
+---@field StartAnim string
+---@field StartFunction fun(door: EntityEffect, data: table, sprite: Sprite, doorData: CustomDoor, doorGridData: table) #doorGridData is the persistData
+---@field StartOverlayAnim string
+---@field StartSound SoundEffect | {[1]: SoundEffect, [2]: number, [3]: integer, [4]: boolean, [5]: number}
+---@field Triggers CustomStateDoor_Triggers
+
+---@class CustomStateDoor_Triggers
+---@field Bomb string | CustomStateDoor_Trigger
+---@field EnteredThrough string | CustomStateDoor_Trigger
+---@field Unclear string | CustomStateDoor_Trigger
+---@field Clear string | CustomStateDoor_Trigger
+---@field Key string | CustomStateDoor_Trigger
+---@field Coin string | CustomStateDoor_Trigger
+---@field GoldKey string | CustomStateDoor_Trigger
+---@field OverlayEvent CustomStateDoor_TriggerOverlayEvent
+---@field FinishOverlayTrigger string | CustomStateDoor_Trigger
+---@field FinishAnimTrigger string | CustomStateDoor_Trigger
+---@field Function fun(door: EntityEffect, data: table, sprite: Sprite, doorData: CustomDoor, doorGridData: table): string | CustomStateDoor_Trigger #doorGridData is the persistData
+
+---@class CustomStateDoor_Trigger
+---@field State string
+---@field Anim string
+---@field OverlayAnim string
+---@field Jingle Music
+---@field Particle CustomStateDoor_TriggerParticle
+---@field Particles CustomStateDoor_TriggerParticle[]
+
+---@class CustomStateDoor_TriggerOverlayEvent : CustomStateDoor_Trigger
+---@field OverlayEvent string
+
+---@class CustomStateDoor_TriggerParticle
+---@field Count integer
+---@field Velocity number
+---@field LifeSpan integer | {[1]: integer, [2]: integer}
+---@field Type integer
+---@field Variant integer
+---@field SubType integer
+---@field Timeout integer
+---@field Rotation number
+
+
+---@class CustomStateDoor : StageAPIClass
 StageAPI.CustomStateDoor = StageAPI.Class("CustomStateDoor")
 
 function StageAPI.CustomStateDoor:Init(name, anm2, states, exitFunction, overlayAnm2, directionOffsets)
@@ -148,6 +227,7 @@ StageAPI.AddCallback("StageAPI", Callbacks.POST_SPAWN_CUSTOM_GRID, 0, function(c
     local index = customGrid.GridIndex
     local persistData = customGrid.PersistentData
 
+    ---@type CustomDoor | CustomStateDoor
     local doorData
     if persistData.DoorDataName and StageAPI.DoorTypes[persistData.DoorDataName] then
         doorData = StageAPI.DoorTypes[persistData.DoorDataName]
@@ -281,6 +361,8 @@ end
 
 local framesWithoutDoorData = 0
 local hadFrameWithoutDoorData = false
+
+---@param door EntityEffect
 mod:AddCallback(ModCallbacks.MC_POST_EFFECT_UPDATE, function(_, door)
     local data, sprite = door:GetData(), door:GetSprite()
     local doorData = data.DoorData
@@ -354,6 +436,7 @@ mod:AddCallback(ModCallbacks.MC_POST_EFFECT_UPDATE, function(_, door)
             local currentRoom = StageAPI.GetCurrentRoom()
             local doorLocked = currentRoom and currentRoom.Metadata:Has({Name = "DoorLocker", Index = shared.Room:GetGridIndex(door.Position)})
 
+            ---@type CustomStateDoor_Trigger
             local trigger
             if stateData.Triggers.Bomb and not doorLocked then
                 if not data.CountedExplosions then

--- a/scripts/stageapi/grid/customgrids.lua
+++ b/scripts/stageapi/grid/customgrids.lua
@@ -5,6 +5,49 @@ local Callbacks = require("scripts.stageapi.enums.Callbacks")
 StageAPI.LogMinor("Loading Custom Grid System")
 
 StageAPI.CustomGridTypes = {}
+
+---@class CustomGridArgs
+---@field BaseType GridEntityType
+---@field BaseVariant integer
+---@field Anm2 string
+---@field Animation string
+---@field Frame integer
+---@field VariantFrames integer max number of random frame to choose from
+---@field Offset Vector
+---@field OverrideGridSpawns boolean
+---@field OverrideGridSpawnsState integer
+---@field ForceSpawning boolean
+---@field NoOverrideGridSprite boolean used for GridGfx
+
+---@param name string
+---@param baseType? GridEntityType
+---@param baseVariant? integer
+---@param anm2? string
+---@param animation? string
+---@param frame? integer
+---@param variantFrames? integer max number of random frame to choose from
+---@param offset? Vector
+---@param overrideGridSpawns? boolean
+---@param overrideGridSpawnAtState? integer
+---@param forceSpawning? boolean
+---@param noOverrideGridSprite? boolean used for GridGfx
+---@return CustomGrid
+---@overload fun(name: string, args: CustomGridArgs): CustomGrid
+function StageAPI.CustomGrid(name, baseType, baseVariant, anm2, animation, frame, variantFrames, offset, overrideGridSpawns, overrideGridSpawnAtState, forceSpawning, noOverrideGridSprite)
+end
+
+---@class CustomGrid : StageAPIClass
+---@field BaseType GridEntityType
+---@field BaseVariant integer
+---@field Anm2 string
+---@field Animation string
+---@field Frame integer
+---@field VariantFrames integer max number of random frame to choose from
+---@field Offset Vector
+---@field OverrideGridSpawns boolean
+---@field OverrideGridSpawnsState integer
+---@field ForceSpawning boolean
+---@field NoOverrideGridSprite boolean used for GridGfx
 StageAPI.CustomGrid = StageAPI.Class("CustomGrid")
 
 function StageAPI.CustomGridArgPacker(baseType, baseVariant, anm2, animation, frame, variantFrames, offset, overrideGridSpawns, overrideGridSpawnAtState, forceSpawning, noOverrideGridSprite)
@@ -53,6 +96,10 @@ StageAPI.DefaultBrokenGridStateByType = {
 
 -- { [dimension] = { [roomId] = { Grids = { [gridPersistIdx] = <grid data> }, LastPersistentIndex = N } } }
 StageAPI.CustomGrids = {}
+
+---@param dimension? integer default: current
+---@param roomID? integer default: current
+---@return {LastPersistentIndex: integer, Grids: CustomGrid[], [integer]: CustomGrid}
 function StageAPI.GetRoomCustomGrids(dimension, roomID)
     local customGrids = StageAPI.GetTableIndexedByDimensionRoom(StageAPI.CustomGrids, true, dimension, roomID)
     if not customGrids.Grids then
@@ -111,6 +158,17 @@ function StageAPI.CustomGrid:Spawn(grindex, force, respawning, persistentData)
 end
 
 StageAPI.CustomGridEntities = {}
+
+---@param gridConfig integer | CustomGrid
+---@param index integer
+---@param force? boolean
+---@param respawning? boolean
+---@param setPersistData? table
+---@return CustomGridEntity
+function StageAPI.CustomGridEntity(gridConfig, index, force, respawning, setPersistData)
+end
+
+---@class CustomGridEntity : StageAPIClass
 StageAPI.CustomGridEntity = StageAPI.Class("CustomGridEntity")
 function StageAPI.CustomGridEntity:Init(gridConfig, index, force, respawning, setPersistData)
     local roomGrids = StageAPI.GetRoomCustomGrids()
@@ -127,6 +185,8 @@ function StageAPI.CustomGridEntity:Init(gridConfig, index, force, respawning, se
 
     local gridData = roomGrids.Grids[self.PersistentIndex]
     if not gridData then
+        assert(gridConfig, "gridConfig cannot be nil while ")
+
         gridData = {Name = gridConfig.Name, Index = index, PersistData = {}}
         roomGrids.Grids[self.PersistentIndex] = gridData
     else
@@ -144,6 +204,8 @@ function StageAPI.CustomGridEntity:Init(gridConfig, index, force, respawning, se
     self.GridIndex = index
     self.Data = {}
 
+    ---either argument, checked if gridData nil, set if gridData not nil
+    ---@diagnostic disable-next-line: need-check-nil
     local grid = gridConfig:SpawnBaseGrid(index, force, respawning)
     self.GridEntity = grid
     if self.GridEntity then

--- a/scripts/stageapi/grid/gridgfx.lua
+++ b/scripts/stageapi/grid/gridgfx.lua
@@ -3,6 +3,11 @@ local mod = require("scripts.stageapi.mod")
 
 StageAPI.LogMinor("Loading GridGfx Handler")
 
+---@return GridGfx
+function StageAPI.GridGfx()
+end
+
+---@class GridGfx : StageAPIClass
 StageAPI.GridGfx = StageAPI.Class("GridGfx")
 function StageAPI.GridGfx:Init()
     self.Grids = false
@@ -562,6 +567,7 @@ function StageAPI.ChangeDoors(doors)
     end
 end
 
+---@param grids GridGfx
 function StageAPI.ChangeGrids(grids)
     StageAPI.GridGfxRNG:SetSeed(shared.Room:GetDecorationSeed(), 0)
 

--- a/scripts/stageapi/library/callbacks.lua
+++ b/scripts/stageapi/library/callbacks.lua
@@ -28,7 +28,7 @@ end
 ---@param id any
 ---@param priority number
 ---@param fn function
----@param ... any # params for the callback
+---@vararg any
 function StageAPI.AddCallback(modID, id, priority, fn, ...)
     if not StageAPI.Callbacks[id] then
         StageAPI.Callbacks[id] = {}

--- a/scripts/stageapi/library/class.lua
+++ b/scripts/stageapi/library/class.lua
@@ -2,7 +2,26 @@ local shared = require("scripts.stageapi.shared")
 
 -- Classes
 
+-- Classes doc annotations for constructors are done
+-- using a placeholder function that will be replaced
+-- immediately after by the actual class object, to make
+-- the job of the Lua language server easier
+
+---@param Type string
+---@param AllowMultipleInit? boolean
+---@return StageAPIClass
+function StageAPI.Class(Type, AllowMultipleInit)
+end
+
+---@class StageAPIClass
+---@field Type string
+---@field private AllowMultipleInit number
+---@field private Initialized boolean
+---@field protected Init fun(self: StageAPIClass, ...: any)
+---@field protected PostInit fun(self: StageAPIClass, ...: any)
+---@field protected InheritInit fun(self: StageAPIClass, ...: any)
 StageAPI.Class = {}
+
 function StageAPI.ClassInit(tbl, ...)
     local inst = {}
     setmetatable(inst, tbl)
@@ -34,5 +53,8 @@ function StageAPI.Class:Init(Type, AllowMultipleInit)
 end
 
 setmetatable(StageAPI.Class, {
+    ---@generic C : StageAPIClass
+    ---@param self C
+    ---@return C
     __call = StageAPI.ClassInit
 })

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -1,6 +1,34 @@
 local shared = require("scripts.stageapi.shared")
 local Callbacks = require("scripts.stageapi.enums.Callbacks")
 
+---@class LevelRoomArgs
+---@field LayoutName string
+---@field RoomsList RoomsList
+---@field SpawnSeed integer
+---@field Shape RoomShape
+---@field RoomType RoomType
+---@field IsExtraRoom boolean
+---@field FromSave boolean
+---@field RequireRoomType boolean
+---@field IgnoreDoors boolean
+---@field Doors table<integer, boolean>
+---@field LevelIndex integer
+---@field IgnoreRoomRules boolean
+
+---Default room args, but not necessarily only possible ones
+---@param layoutName string
+---@param roomsList? RoomsList
+---@param seed? integer
+---@param shape? RoomShape
+---@param roomType? RoomType
+---@param isExtraRoom? boolean
+---@param fromSaveData? boolean
+---@param requireRoomType? boolean
+---@param ignoreDoors? boolean
+---@param doors? table<DoorSlot, boolean>
+---@param levelIndex? integer
+---@param ignoreRoomRules? boolean
+---@return LevelRoomArgs
 function StageAPI.LevelRoomArgPacker(layoutName, roomsList, seed, shape, roomType, isExtraRoom, fromSaveData, requireRoomType, ignoreDoors, doors, levelIndex, ignoreRoomRules)
     return {
         LayoutName = layoutName,
@@ -14,12 +42,49 @@ function StageAPI.LevelRoomArgPacker(layoutName, roomsList, seed, shape, roomTyp
         IgnoreDoors = ignoreDoors,
         Doors = doors,
         LevelIndex = levelIndex,
-        IgnoreRoomRules = ignoreRoomRules
+        IgnoreRoomRules = ignoreRoomRules,
     }
 end
 
 local levelRoomCopyFromArgs = {"IsExtraRoom","LevelIndex", "IgnoreDoors","Doors", "IgnoreShape","Shape","RoomType","SpawnSeed","LayoutName","RequireRoomType","IgnoreRoomRules","DecorationSeed","AwardSeed","VisitCount","IsClear","ClearCount","IsPersistentRoom","HasWaterPits","ChallengeDone","FromData","Dimension","RoomsListName","RoomsListID"}
 
+---@param layoutName string
+---@param roomsList? RoomsList
+---@param seed? integer
+---@param shape? RoomShape
+---@param roomType? RoomType
+---@param isExtraRoom? boolean
+---@param fromSaveData? boolean
+---@param requireRoomType? boolean
+---@param ignoreDoors? boolean
+---@param doors? table<DoorSlot, boolean>
+---@param levelIndex? integer
+---@param ignoreRoomRules? boolean
+---@return LevelRoom
+---@overload fun(args: LevelRoomArgs): LevelRoom
+function StageAPI.LevelRoom(layoutName, roomsList, seed, shape, roomType, isExtraRoom, fromSaveData, requireRoomType, ignoreDoors, doors, levelIndex, ignoreRoomRules)
+end
+--Duplicated field to make this easy on the Lua linter
+
+--- Constructor: (layoutName, roomsList, seed, shape, roomType, isExtraRoom, fromSaveData, requireRoomType, ignoreDoors, doors, levelIndex, ignoreRoomRules)
+--- Or constructor: (args) where args is a table of fields to initialize the room with
+---@class LevelRoom
+---@field LayoutName string
+---@field RoomsList RoomsList
+---@field SpawnSeed integer
+---@field Shape RoomShape
+---@field RoomType RoomType
+---@field IsExtraRoom boolean
+---@field FromSave boolean
+---@field RequireRoomType boolean
+---@field IgnoreDoors boolean
+---@field Doors table<DoorSlot, boolean>
+---@field LevelIndex integer
+---@field IgnoreRoomRules boolean
+---@field FromData boolean
+---@field RoomDescriptor RoomDescriptor #can be passed to initialize the room with the descriptor's data
+---@field RoomsListID integer
+---@field IgnoreShape boolean
 StageAPI.LevelRoom = StageAPI.Class("LevelRoom")
 StageAPI.NextUniqueRoomIdentifier = 0
 function StageAPI.LevelRoom:Init(args, ...)

--- a/scripts/stageapi/room/roomMetadata.lua
+++ b/scripts/stageapi/room/roomMetadata.lua
@@ -2,6 +2,12 @@ local shared = require("scripts.stageapi.shared")
 local mod = require("scripts.stageapi.mod")
 local Callbacks = require("scripts.stageapi.enums.Callbacks")
 
+---@return RoomMetadata
+function StageAPI.RoomMetadata()
+end
+
+---@class RoomMetadata
+---@field LevelRoom LevelRoom
 StageAPI.RoomMetadata = StageAPI.Class("RoomMetadata")
 
 function StageAPI.RoomMetadata:Init()

--- a/scripts/stageapi/room/roomsList.lua
+++ b/scripts/stageapi/room/roomsList.lua
@@ -1,7 +1,18 @@
 local shared = require("scripts.stageapi.shared")
 
 StageAPI.RoomsLists = {}
+
+
+---@param name string
+---@vararg string roomfiles
+---@return RoomsList
+function StageAPI.RoomsList(name, ...)
+end
+
+--- Constructor: (name, roomFiles...)
+---@class RoomsList
 StageAPI.RoomsList = StageAPI.Class("RoomsList")
+
 function StageAPI.RoomsList:Init(name, ...)
     self.Name = name
     StageAPI.RoomsLists[name] = self

--- a/scripts/stageapi/stage/customFloorGen.lua
+++ b/scripts/stageapi/stage/customFloorGen.lua
@@ -9,6 +9,23 @@ StageAPI.CurrentLevelMapRoomID = nil
 
 StageAPI.LevelMapStartingDimension = -2
 
+---@class LevelMapArgs
+---@field Dimension integer
+---@field StartingRoom integer # room ID
+---@field Persistent boolean
+---@field OverlapDimension integer
+
+---@param args? LevelMapArgs
+---@return LevelMap
+function StageAPI.LevelMap(args)
+end
+
+--- Constructor: (args: {Dimension = int, StartingRoom = int, Persistent = bool, OverlapDimension = int})
+---@class LevelMap : StageAPIClass
+---@field Dimension integer
+---@field StartingRoom integer # room ID
+---@field Persistent boolean
+---@field OverlapDimension integer
 StageAPI.LevelMap = StageAPI.Class("LevelMap")
 
 local levelMapDirectCopyFromArgs = {"Dimension", "StartingRoom", "Persistent", "OverlapDimension"}

--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -5,7 +5,21 @@ StageAPI.LogMinor("Loading CustomStage Handler")
 
 StageAPI.CustomStages = {}
 
+---@class OverrideStage
+---@field OverrideStage number
+---@field OverrideStageType number
+---@field ReplaceWith CustomStage
+---@field GreedMode boolean
+
+---@param name string
+---@param replaces? OverrideStage #default: StageAPI.StageOverride.CatacombsOne
+---@param noSetReplaces? boolean
+function StageAPI.CustomStage(name, replaces, noSetReplaces)
+end
+
+---@class CustomStage : StageAPIClass
 StageAPI.CustomStage = StageAPI.Class("CustomStage")
+
 function StageAPI.CustomStage:Init(name, replaces, noSetReplaces)
     self.Name = name
     self.Alias = name

--- a/scripts/stageapi/stage/overlays.lua
+++ b/scripts/stageapi/stage/overlays.lua
@@ -28,6 +28,16 @@ function StageAPI.RenderSpriteTiled(sprite, position, size, centerCorrect)
 end
 
 StageAPI.OverlayDefaultSize = Vector(512, 512)
+
+---@param file string
+---@param velocity? Vector
+---@param offset? Vector
+---@param size? Vector
+---@param alpha? number
+function StageAPI.Overlay(file, velocity, offset, size, alpha)
+end
+
+---@class StageAPIOverlay
 StageAPI.Overlay = StageAPI.Class("Overlay")
 function StageAPI.Overlay:Init(file, velocity, offset, size, alpha)
     self.Sprite = Sprite()

--- a/scripts/stageapi/stage/roomgfx.lua
+++ b/scripts/stageapi/stage/roomgfx.lua
@@ -237,6 +237,12 @@ function StageAPI.ChangeRoomGfx(roomgfx)
     end
 end
 
+---@param backdrops BackdropType | BackdropType[]
+---@param grids GridGfx
+function StageAPI.RoomGfx(backdrops, grids)
+end
+
+---@class RoomGfx
 StageAPI.RoomGfx = StageAPI.Class("RoomGfx")
 function StageAPI.RoomGfx:Init(backdrops, grids)
     self.Backdrops = backdrops


### PR DESCRIPTION
Added EmmyLUA autocomplete annotations (compatible for instance with the VSCode lua language server). As it doesn't recognize metamethods by default, to make constructors work I used this pattern

```Lua
---@param arg1 type
---@param arg2 type
---@return MyClass
function StageAPI.MyClass(arg1, arg2)
end

---@class MyClass
StageAPI.MyClass= StageAPI.Class("MyClass")

function StageAPI.MyClass:Init(arg1, arg2)
[...]
end
```