### PR TITLE
Control for custom grid drops

### DIFF
--- a/scripts/stageapi/grid/customgrids.lua
+++ b/scripts/stageapi/grid/customgrids.lua
@@ -155,9 +155,9 @@ StageAPI.PoopDropChances = {
 }
 
 StageAPI.PetrifiedPoopDropChances = {
-    [PickupVariant.PICKUP_COIN] = 10.5 / 100,
-    [PickupVariant.PICKUP_HEART] = 3.75 / 100,
-    [PickupVariant.PICKUP_TRINKET] = 0.75 / 100, -- petrified poop
+    [PickupVariant.PICKUP_COIN] = 35 / 100,
+    [PickupVariant.PICKUP_HEART] = 12.5 / 100,
+    [PickupVariant.PICKUP_TRINKET] = 2.5 / 100, -- petrified poop
 }
 
 -- { [dimension] = { [roomId] = { Grids = { [gridPersistIdx] = <grid data> }, LastPersistentIndex = N } } }

--- a/scripts/stageapi/room/roomHandler.lua
+++ b/scripts/stageapi/room/roomHandler.lua
@@ -854,6 +854,7 @@ function StageAPI.SetCurrentRoom(room)
     StageAPI.SetLevelRoom(room, StageAPI.GetCurrentRoomID())
 end
 
+---@return LevelRoom
 function StageAPI.GetCurrentRoom()
     return StageAPI.GetLevelRoom(StageAPI.GetCurrentRoomID())
 end


### PR DESCRIPTION
New fields for CustomGrid:
* RemoveDrops
* RemovePetrifiedPoop
* RemovePetrifiedPoopExtraDrops

Can be used to control drops for custom grid entities based on poops, and in general.

Needs to know how petrified poop affects drop rates, current values are similar but not perfect.
