### PR TITLE
Room-specific music

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -273,6 +273,12 @@ Callback List:
 
   - Return a number to use that MusicID as music, not running further callbacks.
 
+- POST_SELECT_ROOM_MUSIC(currentstage, musicID, baseRoomType, roomId, musicRNG)
+
+  - Return a number to use that MusicID as music, not running further callbacks.
+  - Overrides stage callbacks if something is returned
+  - Ran for StageAPI rooms, even in vanilla floors (in that case, extra rooms)
+
 - POST_SELECT_STAGE_MUSIC(currentstage, musicID, roomType, musicRNG)
 
   - Return a number to use that MusicID as music, not running further callbacks.

--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -382,15 +382,12 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     then
         local id = shared.Music:GetCurrentMusicID()
         local musicID, shouldLayer, shouldQueue, disregardNonOverride
-        if StageAPI.CurrentStage then
-            musicID, shouldLayer, shouldQueue, disregardNonOverride = StageAPI.CurrentStage:GetPlayingMusic()
+        if musicRoom then
+            musicID, shouldLayer = musicRoom:GetPlayingMusic()
         end
 
-        if musicRoom then
-            local rMusicID, rShouldLayer = musicRoom:GetPlayingMusic()
-            if rMusicID then
-                musicID, shouldLayer, shouldQueue, disregardNonOverride = rMusicID, rShouldLayer, nil, nil
-            end
+        if not musicID and StageAPI.CurrentStage then
+            musicID, shouldLayer, shouldQueue, disregardNonOverride = StageAPI.CurrentStage:GetPlayingMusic()
         end
 
         if musicID then

--- a/scripts/stageapi/enums/Callbacks.lua
+++ b/scripts/stageapi/enums/Callbacks.lua
@@ -45,7 +45,7 @@ local Callbacks = {
     POST_SELECT_BOSS_MUSIC = "POST_SELECT_BOSS_MUSIC", -- (currentstage, musicID, isCleared, musicRNG)
     POST_SELECT_CHALLENGE_MUSIC = "POST_SELECT_CHALLENGE_MUSIC", -- (currentstage, musicID, isCleared, musicRNG)
     POST_SELECT_STAGE_MUSIC = "POST_SELECT_STAGE_MUSIC", -- (currentstage, musicID, roomType, musicRNG)
-    POST_SELECT_ROOM_MUSIC = "POST_SELECT_ROOM_MUSIC", -- (currentRoom, musicID, baseRoomType, roomId, musicRNG) # Used by stageapi rooms with Music set or UseRoomMusicHandling = true
+    POST_SELECT_ROOM_MUSIC = "POST_SELECT_ROOM_MUSIC", -- (currentRoom, musicID, baseRoomType, roomId, musicRNG)
     POST_ROOM_CLEAR = "POST_ROOM_CLEAR", -- ()
     PRE_STAGEAPI_SELECT_BOSS_ITEM = "PRE_STAGEAPI_SELECT_BOSS_ITEM", -- (pickup, currentRoom)
     PRE_STAGEAPI_LOAD_SAVE = "PRE_STAGEAPI_LOAD_SAVE", -- ()

--- a/scripts/stageapi/enums/Callbacks.lua
+++ b/scripts/stageapi/enums/Callbacks.lua
@@ -45,6 +45,7 @@ local Callbacks = {
     POST_SELECT_BOSS_MUSIC = "POST_SELECT_BOSS_MUSIC", -- (currentstage, musicID, isCleared, musicRNG)
     POST_SELECT_CHALLENGE_MUSIC = "POST_SELECT_CHALLENGE_MUSIC", -- (currentstage, musicID, isCleared, musicRNG)
     POST_SELECT_STAGE_MUSIC = "POST_SELECT_STAGE_MUSIC", -- (currentstage, musicID, roomType, musicRNG)
+    POST_SELECT_ROOM_MUSIC = "POST_SELECT_ROOM_MUSIC", -- (currentRoom, musicID, roomType, roomId, musicRNG) # Used by stageapi rooms with Music set or UseRoomMusicHandling = true
     POST_ROOM_CLEAR = "POST_ROOM_CLEAR", -- ()
     PRE_STAGEAPI_SELECT_BOSS_ITEM = "PRE_STAGEAPI_SELECT_BOSS_ITEM", -- (pickup, currentRoom)
     PRE_STAGEAPI_LOAD_SAVE = "PRE_STAGEAPI_LOAD_SAVE", -- ()

--- a/scripts/stageapi/enums/Callbacks.lua
+++ b/scripts/stageapi/enums/Callbacks.lua
@@ -45,7 +45,7 @@ local Callbacks = {
     POST_SELECT_BOSS_MUSIC = "POST_SELECT_BOSS_MUSIC", -- (currentstage, musicID, isCleared, musicRNG)
     POST_SELECT_CHALLENGE_MUSIC = "POST_SELECT_CHALLENGE_MUSIC", -- (currentstage, musicID, isCleared, musicRNG)
     POST_SELECT_STAGE_MUSIC = "POST_SELECT_STAGE_MUSIC", -- (currentstage, musicID, roomType, musicRNG)
-    POST_SELECT_ROOM_MUSIC = "POST_SELECT_ROOM_MUSIC", -- (currentRoom, musicID, roomType, roomId, musicRNG) # Used by stageapi rooms with Music set or UseRoomMusicHandling = true
+    POST_SELECT_ROOM_MUSIC = "POST_SELECT_ROOM_MUSIC", -- (currentRoom, musicID, baseRoomType, roomId, musicRNG) # Used by stageapi rooms with Music set or UseRoomMusicHandling = true
     POST_ROOM_CLEAR = "POST_ROOM_CLEAR", -- ()
     PRE_STAGEAPI_SELECT_BOSS_ITEM = "PRE_STAGEAPI_SELECT_BOSS_ITEM", -- (pickup, currentRoom)
     PRE_STAGEAPI_LOAD_SAVE = "PRE_STAGEAPI_LOAD_SAVE", -- ()

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -633,7 +633,7 @@ function StageAPI.LevelRoom:GetPlayingMusic()
 
         local newMusicID = StageAPI.CallCallbacks(
             Callbacks.POST_SELECT_ROOM_MUSIC, true, 
-            self, musicID, roomType, StageAPI.GetCurrentRoomID(), StageAPI.MusicRNG
+            self, musicID, roomType, self.LevelIndex, StageAPI.MusicRNG
         )
         if newMusicID then
             musicID = newMusicID

--- a/scripts/stageapi/stage/customFloorGen.lua
+++ b/scripts/stageapi/stage/customFloorGen.lua
@@ -835,6 +835,7 @@ function StageAPI.LoadCustomMapRoomDoors(levelRoom, roomData, levelMap)
     levelMap = levelMap or StageAPI.GetCurrentLevelMap()
     if roomData.Doors then
         for slot, doorData in pairs(roomData.Doors) do
+            ---@type LevelRoom
             local targetLevelRoom = levelMap:GetRoom(doorData.ExitRoom)
             local cancelSpawn = StageAPI.CallCallbacks(Callbacks.PRE_LEVELMAP_SPAWN_DOOR, true, slot, doorData, levelRoom, targetLevelRoom, roomData, levelMap)
 

--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -174,6 +174,8 @@ function StageAPI.CustomStage:SetGreedModeWaves(rooms, bossRooms, devilRooms)
     }
 end
 
+---@param music Music
+---@param rtype RoomType
 function StageAPI.CustomStage:SetMusic(music, rtype)
     if not self.Music then
         self.Music = {}

--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -18,6 +18,7 @@ function StageAPI.CustomStage(name, replaces, noSetReplaces)
 end
 
 ---@class CustomStage : StageAPIClass
+---@field Music table<RoomType, Music>
 StageAPI.CustomStage = StageAPI.Class("CustomStage")
 
 function StageAPI.CustomStage:Init(name, replaces, noSetReplaces)
@@ -538,6 +539,10 @@ function StageAPI.CustomStage:GenerateLevel()
     end
 end
 
+---@return Music? musicId
+---@return boolean? shouldLayer
+---@return Music? shouldQueue
+---@return boolean? disregardNonOverride
 function StageAPI.CustomStage:GetPlayingMusic()
     local roomType = shared.Room:GetType()
     local id = shared.Music:GetCurrentMusicID()

--- a/scripts/stageapi/stage/extrarooms.lua
+++ b/scripts/stageapi/stage/extrarooms.lua
@@ -444,6 +444,15 @@ function StageAPI.GetExtraRoomBaseGridRooms(nextIsBoss)
     return default, alternate, largeDefault, largeAlternate
 end
 
+---@param levelMapRoomID any
+---@param direction? Direction
+---@param transitionType? RoomTransitionAnim | -1 # -1 for instant transition
+---@param levelMapID? Dimension
+---@param leaveDoor? DoorSlot
+---@param enterDoor? DoorSlot
+---@param setPlayerPosition? Vector
+---@param extraRoomBaseType? RoomType
+---@param noSave? boolean
 function StageAPI.ExtraRoomTransition(levelMapRoomID, direction, transitionType, levelMapID, leaveDoor, enterDoor, setPlayerPosition, extraRoomBaseType, noSave)
     leaveDoor = leaveDoor or -1
     enterDoor = enterDoor or -1
@@ -606,6 +615,9 @@ function StageAPI.ExtraRoomTransition(levelMapRoomID, direction, transitionType,
 
         shared.Game:StartRoomTransition(transitionTo, direction, transitionType)
     end
+
+    -- To check if doing transition either to or from extra room
+    StageAPI.DoingExtraRoomTransition = true
 end
 
 mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()


### PR DESCRIPTION
Added fields to LevelRoom and a callback to support room-specific music, especially for extra rooms in vanilla floors.

+ Add a `Music` field to LevelRoom, can be specified on creation or after to make the room have a separate track.
+ Add *POST_SELECT_ROOM_MUSIC* callback, similar to the other music callbacks, has priority on stage music if something is returned, and works in stageapi rooms inside of vanilla floors too