### PR TITLE
Fix The Stairway (& similar) + custom level gen

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -775,7 +775,13 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
             StageAPI.DoubleTransitioning = true
             local replace = StageAPI.NextStage.Replaces
             shared.Level:SetStage(replace.OverrideStage, replace.OverrideStageType)
-            shared.Level:ChangeRoom(shared.Level:GetCurrentRoomIndex())
+            local currentRoomIndex = shared.Level:GetCurrentRoomIndex()
+
+            -- let on first room visit effects trigger (like The Stairway item)
+            local editableCurrentDesc = shared.Level:GetRoomByIdx(currentRoomIndex)
+            editableCurrentDesc.VisitedCount = 0
+
+            shared.Level:ChangeRoom(currentRoomIndex)
             return
         end
     end


### PR DESCRIPTION
Fix items like The Stairway that act on first room visit in starting room with custom level gen stages.