### PR TITLE
Strip out zero width spaces from player name in "VS" miniboss text

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1066,7 +1066,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
                 end
             end
         else
-            local text = shared.Players[1]:GetName() .. " VS " .. boss.Name
+            local text = StageAPI.SanitizeString(shared.Players[1]:GetName()) .. " VS " .. boss.Name
 
             local ret = StageAPI.CallCallbacks(Callbacks.PRE_PLAY_MINIBOSS_STREAK, true, currentRoom, boss, text)
 

--- a/scripts/stageapi/library/misc.lua
+++ b/scripts/stageapi/library/misc.lua
@@ -194,3 +194,7 @@ function StageAPI.AnyPlayerHasTrinket(trinketType)
 
     return false
 end
+
+function StageAPI.SanitizeString(playerName)
+    return string.gsub(playerName, "%​", "") -- Unicode 8203 "Zero Width Space"
+end

--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -474,7 +474,7 @@ function StageAPI.CustomStageGenerateRoom(currentStage, roomDescriptor, isStarti
             if usingRoomsList:GetRooms(shape) then
                 local replaceVsText
                 if lastReplacedSuperSin then
-                    replaceVsText = shared.Players[1]:GetName() .. " VS " .. lastReplacedSuperSin
+                    replaceVsText = StageAPI.SanitizeString(shared.Players[1]:GetName()) .. " VS " .. lastReplacedSuperSin
                 end
 
                 local newRoom = StageAPI.LevelRoom(StageAPI.Merged({


### PR DESCRIPTION
This unicode character, used in the Epiphany mod for character names to not clash with the names of vanilla character, causes issues when displayed in StageAPI miniboss rooms. To fix this, these player names now have zero width spaces stripped out before being displayed
Before:
![20221105221024_1](https://user-images.githubusercontent.com/48618519/200143779-39d9c845-2324-4cb2-994a-5083549cc5de.jpg)
After:
![20221105222301_1](https://user-images.githubusercontent.com/48618519/200143788-9fd2309a-edf2-48a8-9b0f-e913bb7c38fd.jpg)
