### PR TITLE
Extra portraits support

### DIFF
--- a/scripts/stageapi/stage/bosses.lua
+++ b/scripts/stageapi/stage/bosses.lua
@@ -169,11 +169,12 @@ StageAPI.PlayerBossInfo[PlayerType.PLAYER_THELOST_B].NoShake = true
 
 -- bossportrait is optional since Repentance, used if you want
 -- your character to have a different boss portrait than the stage one
-function StageAPI.AddPlayerGraphicsInfo(playertype, portrait, namefile, noshake, bossportrait)
+function StageAPI.AddPlayerGraphicsInfo(playertype, portrait, namefile, noshake, bossportrait, extraportrait)
     local args = portrait
     if type(args) ~= "table" then
         args = {
             Portrait = portrait,
+            ExtraPortrait = extraportrait,
             Name = namefile,
             BossPortrait = bossportrait,
             NoShake = noshake,

--- a/scripts/stageapi/stage/bosses.lua
+++ b/scripts/stageapi/stage/bosses.lua
@@ -167,6 +167,8 @@ StageAPI.PlayerBossInfo[PlayerType.PLAYER_THEFORGOTTEN_B].ControlsFrame = 1
 StageAPI.PlayerBossInfo[PlayerType.PLAYER_THESOUL_B].ControlsFrame = 1
 StageAPI.PlayerBossInfo[PlayerType.PLAYER_THELOST_B].NoShake = true
 
+StageAPI.PlayerBossInfo[PlayerType.PLAYER_EDEN_B].ExtraPortrait = "gfx/ui/stage/eden_b_head.anm2"
+
 -- bossportrait is optional since Repentance, used if you want
 -- your character to have a different boss portrait than the stage one
 function StageAPI.AddPlayerGraphicsInfo(playertype, portrait, namefile, noshake, bossportrait, extraportrait)

--- a/scripts/stageapi/stage/transitions.lua
+++ b/scripts/stageapi/stage/transitions.lua
@@ -95,7 +95,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         StageAPI.TransitionIsPlaying = true
         StageAPI.RenderBlackScreen()
         StageAPI.TransitionAnimation:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
-        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition() + Vector(-74 + StageAPI.ShakeOffset, -17)--[[Magic trial and error numbers to make it work without adjusting anm2 files]], Vector.Zero, Vector.Zero)
+        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition() + Vector(-72 + StageAPI.ShakeOffset, -19)--[[Magic trial and error numbers to make it work without adjusting anm2 files]], Vector.Zero, Vector.Zero)
     elseif StageAPI.TransitionIsPlaying then -- Finished transition
         StageAPI.TransitionIsPlaying = false
         if StageAPI.CurrentStage then

--- a/scripts/stageapi/stage/transitions.lua
+++ b/scripts/stageapi/stage/transitions.lua
@@ -86,7 +86,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         StageAPI.TransitionIsPlaying = true
         StageAPI.RenderBlackScreen()
         StageAPI.TransitionAnimation:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
-        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
+        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition() + Vector(-74, -17)--[[Magic trial and error numbers to make it work without adjusting anm2 files]], Vector.Zero, Vector.Zero)
     elseif StageAPI.TransitionIsPlaying then -- Finished transition
         StageAPI.TransitionIsPlaying = false
         if StageAPI.CurrentStage then

--- a/scripts/stageapi/stage/transitions.lua
+++ b/scripts/stageapi/stage/transitions.lua
@@ -52,11 +52,20 @@ function StageAPI.RenderBlackScreen(alpha)
     StageAPI.BlackScreenOverlay:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
 end
 
+StageAPI.ShakeOffset = -1
+StageAPI.ShakeOffsetInc = 1 -- Inc = Increment
 mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     if StageAPI.TransitionAnimation:IsPlaying("Scene") or StageAPI.TransitionAnimation:IsPlaying("SceneNoShake") or StageAPI.TransitionAnimation:IsPlaying("Intro") then
         if StageAPI.IsOddRenderFrame then
             StageAPI.TransitionAnimation:Update()
             StageAPI.ExtraPortrait:Update()
+
+            StageAPI.ShakeOffset = StageAPI.ShakeOffset + StageAPI.ShakeOffsetInc
+            if StageAPI.ShakeOffset >= 1 then
+                StageAPI.ShakeOffsetInc = -1
+            elseif StageAPI.ShakeOffset <= -1 then
+                StageAPI.ShakeOffsetInc = 1
+            end
         end
 
         local stop
@@ -86,7 +95,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         StageAPI.TransitionIsPlaying = true
         StageAPI.RenderBlackScreen()
         StageAPI.TransitionAnimation:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
-        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition() + Vector(-74, -17)--[[Magic trial and error numbers to make it work without adjusting anm2 files]], Vector.Zero, Vector.Zero)
+        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition() + Vector(-74 + StageAPI.ShakeOffset, -17)--[[Magic trial and error numbers to make it work without adjusting anm2 files]], Vector.Zero, Vector.Zero)
     elseif StageAPI.TransitionIsPlaying then -- Finished transition
         StageAPI.TransitionIsPlaying = false
         if StageAPI.CurrentStage then
@@ -186,6 +195,9 @@ function StageAPI.PlayTransitionAnimationManual(portrait, icon, ground, bg, tran
     else
         StageAPI.ExtraPortrait = Sprite()
     end
+
+    StageAPI.ShakeOffset = -1
+    StageAPI.ShakeOffsetInc = 1
 
     shared.Music:Play(transitionmusic, 0)
     shared.Music:UpdateVolume()

--- a/scripts/stageapi/stage/transitions.lua
+++ b/scripts/stageapi/stage/transitions.lua
@@ -32,6 +32,7 @@ StageAPI.StageTypes = {
 
 StageAPI.TransitionAnimation = Sprite()
 StageAPI.TransitionAnimation:Load("stageapi/transition/customnightmare.anm2", true)
+StageAPI.ExtraPortrait = Sprite()
 
 StageAPI.RemovedHUD = false
 StageAPI.TransitionIsPlaying = false
@@ -55,6 +56,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     if StageAPI.TransitionAnimation:IsPlaying("Scene") or StageAPI.TransitionAnimation:IsPlaying("SceneNoShake") or StageAPI.TransitionAnimation:IsPlaying("Intro") then
         if StageAPI.IsOddRenderFrame then
             StageAPI.TransitionAnimation:Update()
+            StageAPI.ExtraPortrait:Update()
         end
 
         local stop
@@ -84,6 +86,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         StageAPI.TransitionIsPlaying = true
         StageAPI.RenderBlackScreen()
         StageAPI.TransitionAnimation:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
+        StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
     elseif StageAPI.TransitionIsPlaying then -- Finished transition
         StageAPI.TransitionIsPlaying = false
         if StageAPI.CurrentStage then
@@ -153,7 +156,7 @@ function StageAPI.GetLevelTransitionIcon(stage, stype)
     return "stageapi/transition/levelicons/" .. base .. ".png"
 end
 
-function StageAPI.PlayTransitionAnimationManual(portrait, icon, ground, bg, transitionmusic, queue, noshake)
+function StageAPI.PlayTransitionAnimationManual(portrait, icon, ground, bg, transitionmusic, queue, noshake, extraportrait)
     portrait = portrait or "gfx/ui/stage/playerportrait_isaac.png"
     icon = icon or "stageapi/transition/levelicons/unknown.png"
     ground = ground or "stageapi/transition/bossspot_01_basement.png"
@@ -177,6 +180,13 @@ function StageAPI.PlayTransitionAnimationManual(portrait, icon, ground, bg, tran
     StageAPI.TransitionAnimation:LoadGraphics()
     StageAPI.TransitionAnimation:Play("Intro", true)
 
+    if extraportrait then
+        StageAPI.ExtraPortrait:Load(extraportrait, true)
+        StageAPI.ExtraPortrait:Play("Idle", true)
+    else
+        StageAPI.ExtraPortrait = Sprite()
+    end
+
     shared.Music:Play(transitionmusic, 0)
     shared.Music:UpdateVolume()
 
@@ -187,7 +197,7 @@ end
 
 function StageAPI.PlayTransitionAnimation(stage)
     local gfxData = StageAPI.TryGetPlayerGraphicsInfo(shared.Players[1])
-    StageAPI.PlayTransitionAnimationManual(gfxData.Portrait, stage.TransitionIcon, stage.TransitionGround, stage.TransitionBackground, stage.TransitionMusic, stage.Music and stage.Music[RoomType.ROOM_DEFAULT], gfxData.NoShake)
+    StageAPI.PlayTransitionAnimationManual(gfxData.Portrait, stage.TransitionIcon, stage.TransitionGround, stage.TransitionBackground, stage.TransitionMusic, stage.Music and stage.Music[RoomType.ROOM_DEFAULT], gfxData.NoShake, gfxData.ExtraPortrait)
 end
 
 StageAPI.StageRNG = RNG()

--- a/scripts/stageapi/stage/transitions.lua
+++ b/scripts/stageapi/stage/transitions.lua
@@ -54,6 +54,29 @@ end
 
 StageAPI.ShakeOffset = -1
 StageAPI.ShakeOffsetInc = 1 -- Inc = Increment
+
+StageAPI.StageTransitionFadeIn = {
+    10,  --0
+    10,  --1
+    11,  --2
+    12,  --3
+    13,  --4
+    15,  --5
+    42,  --6
+    70,  --7
+    97,  --8
+    125, --9
+    152, --10
+    180, --11
+    192, --12
+    205, --13
+    217, --14
+    230, --15
+    242, --16
+    255  --17
+}
+StageAPI.StageTransitionFadeInCounter = 0
+
 mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     if StageAPI.TransitionAnimation:IsPlaying("Scene") or StageAPI.TransitionAnimation:IsPlaying("SceneNoShake") or StageAPI.TransitionAnimation:IsPlaying("Intro") then
         if StageAPI.IsOddRenderFrame then
@@ -66,7 +89,15 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
             elseif StageAPI.ShakeOffset <= -1 then
                 StageAPI.ShakeOffsetInc = 1
             end
+
+            StageAPI.StageTransitionFadeInCounter = math.min(StageAPI.StageTransitionFadeInCounter + 1, 16)
         end
+        local FadeInTint = Color(
+                             StageAPI.StageTransitionFadeIn[StageAPI.StageTransitionFadeInCounter] / 255, --R
+                             StageAPI.StageTransitionFadeIn[StageAPI.StageTransitionFadeInCounter] / 255, --G
+                             StageAPI.StageTransitionFadeIn[StageAPI.StageTransitionFadeInCounter] / 255  --B
+                            )
+        
 
         local stop
         for _, player in ipairs(shared.Players) do
@@ -95,6 +126,8 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         StageAPI.TransitionIsPlaying = true
         StageAPI.RenderBlackScreen()
         StageAPI.TransitionAnimation:Render(StageAPI.GetScreenCenterPosition(), Vector.Zero, Vector.Zero)
+
+        StageAPI.ExtraPortrait.Color = FadeInTint
         StageAPI.ExtraPortrait:Render(StageAPI.GetScreenCenterPosition() + Vector(-72 + StageAPI.ShakeOffset, -19)--[[Magic trial and error numbers to make it work without adjusting anm2 files]], Vector.Zero, Vector.Zero)
     elseif StageAPI.TransitionIsPlaying then -- Finished transition
         StageAPI.TransitionIsPlaying = false
@@ -198,6 +231,7 @@ function StageAPI.PlayTransitionAnimationManual(portrait, icon, ground, bg, tran
 
     StageAPI.ShakeOffset = -1
     StageAPI.ShakeOffsetInc = 1
+    StageAPI.StageTransitionFadeInCounter = 0
 
     shared.Music:Play(transitionmusic, 0)
     shared.Music:UpdateVolume()


### PR DESCRIPTION
The base game, as well as some mods, use a stage transition portrait feature called "Extra Portraits". These extra portraits are anm2 files that are fed in through the players.xml file, and allow an animation to be overlayed with the usual transition sprite. This pull request adds a new `StageAPI.AddPlayerGraphicsInfo`field called `ExtraPortrait`, which is a string pointing to an anm2 file, and this anm2 file will be drawn to the screen along with the usual stage transition sprite, just like in the base game.

Here is a video of this new field in action using Tainted Eden as an example:
https://streamable.com/no4il3

