### PR TITLE
DrawStringScaled to DrawStringScaledUTF8

### DIFF
--- a/scripts/stageapi/library/streaks.lua
+++ b/scripts/stageapi/library/streaks.lua
@@ -206,14 +206,14 @@ local function RenderStreaksInTable(streakTable)
 
             local height = streakPlaying.Font:GetLineHeight() * streakPlaying.LineSpacing * streakPlaying.FontScale.Y
             for i, line in ipairs(streakPlaying.Text) do
-                streakPlaying.Font:DrawStringScaled(line.Text,
+                streakPlaying.Font:DrawStringScaledUTF8(line.Text,
                                                     line.PositionX + streakPlaying.TextOffset.X,
                                                     streakPlaying.RenderPos.Y - 9 + (i - 1) * height  + streakPlaying.TextOffset.Y,
                                                     streakPlaying.FontScale.X, streakPlaying.FontScale.Y,
                                                     streakPlaying.Color, 0, true)
             end
             if streakPlaying.ExtraText then
-                streakPlaying.SmallFont:DrawStringScaled(streakPlaying.ExtraText, streakPlaying.ExtraPositionX + streakPlaying.ExtraOffset.X, (streakPlaying.RenderPos.Y - 9) + streakPlaying.ExtraOffset.Y, streakPlaying.FontScale.X * streakPlaying.ExtraFontScale.X, 1 * streakPlaying.ExtraFontScale.Y, streakPlaying.Color, 0, true)
+                streakPlaying.SmallFont:DrawStringScaledUTF8(streakPlaying.ExtraText, streakPlaying.ExtraPositionX + streakPlaying.ExtraOffset.X, (streakPlaying.RenderPos.Y - 9) + streakPlaying.ExtraOffset.Y, streakPlaying.FontScale.X * streakPlaying.ExtraFontScale.X, 1 * streakPlaying.ExtraFontScale.Y, streakPlaying.Color, 0, true)
             end
 
             StageAPI.CallCallbacks(Callbacks.POST_STREAK_RENDER, false, streakPlaying.RenderPos, streakPlaying)


### PR DESCRIPTION
This change fixes a problem with displaying non-Latin and other special characters. 
For example zero width spaces used in the Epiphany mod.
before
![20221111215236_1](https://user-images.githubusercontent.com/117683466/201391300-91378e58-1a34-42f8-bfa4-511d9df4b8f5.jpg)
after
![20221111214318_1](https://user-images.githubusercontent.com/117683466/201391543-cc443235-aa3f-4687-83c4-c5d5801f08f4.jpg)

before
![20221111210828_1](https://user-images.githubusercontent.com/117683466/201391965-df1d2d23-4ebe-418a-aac0-d309ec8936c0.jpg)
after
![20221111213306_1](https://user-images.githubusercontent.com/117683466/201391986-52768a41-a668-4ca1-95bd-e04e3f8a39a9.jpg)
