### PR TITLE
Added opacity argument to ChangeStageShadow

### DIFF
--- a/content/entities2.xml
+++ b/content/entities2.xml
@@ -5,7 +5,7 @@
     <entity anm2path="stageapi/none.anm2" id="1000" name="StageAPIBackdrop" variant="12538" collisionRadius="0" numGridCollisionPoints="0">
         <gibs amount="0" blood="0" bone="0" eye="0" gut="0" large="0" />
     </entity>
-    <entity anm2path="stageapi/none.anm2" id="1000" name="StageAPIStageShadow" variant="12548" collisionRadius="0" numGridCollisionPoints="0">
+    <entity anm2path="stageapi/stage_shadow.anm2" id="1000" name="StageAPIStageShadow" variant="12548" collisionRadius="0" numGridCollisionPoints="0">
         <gibs amount="0" blood="0" bone="0" eye="0" gut="0" large="0" />
     </entity>
     <entity anm2path="stageapi/none.anm2" id="1000" name="StageAPIGenericEffect" variant="12544" collisionRadius="0" numGridCollisionPoints="0">

--- a/scripts/stageapi/stage/extrarooms.lua
+++ b/scripts/stageapi/stage/extrarooms.lua
@@ -658,7 +658,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
             if shadowAnim and not (shadowSprite:IsPlaying(shadowAnim) or shadowSprite:IsFinished(shadowAnim)) then
                 shadowSprite:Play(shadowAnim, true)
             end
-
+            shadowSprite.Color = shadow.Color
             shadowSprite:Render(Isaac.WorldToRenderPosition(shadow.Position) + shared.Room:GetRenderScrollOffset(), Vector.Zero, Vector.Zero)
         end
     end

--- a/scripts/stageapi/stage/extrarooms.lua
+++ b/scripts/stageapi/stage/extrarooms.lua
@@ -645,7 +645,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
             end
         end
 
-        local shadows = Isaac.FindByType(StageAPI.E.StageShadow.T, StageAPI.E.StageShadow.V, -1, false, false)
+        --[[local shadows = Isaac.FindByType(StageAPI.E.StageShadow.T, StageAPI.E.StageShadow.V, -1, false, false)
         local shadow = shadows[1]
         if shadow then
             local shadowSheet, shadowAnim = shadow:GetData().Sheet, shadow:GetData().Animation
@@ -660,7 +660,7 @@ mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
             end
             shadowSprite.Color = shadow.Color
             shadowSprite:Render(Isaac.WorldToRenderPosition(shadow.Position) + shared.Room:GetRenderScrollOffset(), Vector.Zero, Vector.Zero)
-        end
+        end]]
     end
 
     StageAPI.CallCallbacks(Callbacks.PRE_TRANSITION_RENDER)

--- a/scripts/stageapi/stage/roomgfx.lua
+++ b/scripts/stageapi/stage/roomgfx.lua
@@ -219,6 +219,10 @@ function StageAPI.ChangeStageShadow(prefix, count, opacity)
         shadowEntity:GetData().Animation = anim
         shadowEntity.Position = StageAPI.Lerp(shared.Room:GetTopLeftPos(), shared.Room:GetBottomRightPos(), 0.5)
         shadowEntity.Color = Color(1,1,1,opacity)
+        shadowEntity.DepthOffset = 99999
+        shadowEntity:GetSprite():ReplaceSpritesheet(0, sheet)
+        shadowEntity:GetSprite():LoadGraphics()
+        shadowEntity:GetSprite():SetFrame(anim, 0)
         shadowEntity:AddEntityFlags(EntityFlag.FLAG_DONT_OVERWRITE)
     end
 end

--- a/scripts/stageapi/stage/roomgfx.lua
+++ b/scripts/stageapi/stage/roomgfx.lua
@@ -190,9 +190,10 @@ function StageAPI.ChangeBackdrop(backdrop, justWalls, storeBackdropEnts)
 end
 
 StageAPI.StageShadowRNG = RNG()
-function StageAPI.ChangeStageShadow(prefix, count)
+function StageAPI.ChangeStageShadow(prefix, count, opacity)
     prefix = prefix or "stageapi/floors/catacombs/overlays/"
     count = count or 5
+    opacity = opacity or 1
 
     local shadows = Isaac.FindByType(StageAPI.E.StageShadow.T, StageAPI.E.StageShadow.V, -1, false, false)
     for _, e in ipairs(shadows) do
@@ -217,6 +218,7 @@ function StageAPI.ChangeStageShadow(prefix, count)
         shadowEntity:GetData().Sheet = sheet
         shadowEntity:GetData().Animation = anim
         shadowEntity.Position = StageAPI.Lerp(shared.Room:GetTopLeftPos(), shared.Room:GetBottomRightPos(), 0.5)
+        shadowEntity.Color = Color(1,1,1,opacity)
         shadowEntity:AddEntityFlags(EntityFlag.FLAG_DONT_OVERWRITE)
     end
 end


### PR DESCRIPTION
Currently the shadow does not properly render in the center of the room during the room transition, as room:GetRenderScrollOffset() does not work and always returns the same vector.