### PR TITLE
Save marshaling (int tables, vectors)

### DIFF
--- a/scripts/stageapi/basic.lua
+++ b/scripts/stageapi/basic.lua
@@ -258,26 +258,17 @@ end
 if Isaac.GetPlayer(0) then
     shared.Room = shared.Game:GetRoom()
     shared.Level = shared.Game:GetLevel()
-    local numPlayers = shared.Game:GetNumPlayers()
-    if numPlayers > 0 then
-        for i = 1, numPlayers do
-            shared.Players[i] = Isaac.GetPlayer(i - 1)
-        end
-    end
 end
 
-mod:AddCallback(ModCallbacks.MC_POST_UPDATE, function()
-    shared.Players = {}
+function StageAPI.GetPlayers()
+    local players = {}
     for i = 1, shared.Game:GetNumPlayers() do
-        shared.Players[i] = Isaac.GetPlayer(i - 1)
+        players[i] = Isaac.GetPlayer(i - 1)
     end
-end)
+    return players
+end
 
 mod:AddPriorityCallback(ModCallbacks.MC_POST_NEW_ROOM, CallbackPriority.IMPORTANT, function()
     shared.Level = shared.Game:GetLevel()
     shared.Room = shared.Game:GetRoom()
-end)
-
-mod:AddCallback(ModCallbacks.MC_PRE_GAME_EXIT, function(_, shouldSave)
-    shared.Players = {}
 end)

--- a/scripts/stageapi/shared.lua
+++ b/scripts/stageapi/shared.lua
@@ -11,16 +11,21 @@ sharedVars.ItemConfig = Isaac.GetItemConfig()
 sharedVars.Room = room
 ---@type Level
 sharedVars.Level = level
----@type EntityPlayer[]
-sharedVars.Players = {}
+if false then -- for vscode autocompletion, do not actually run as it gets metatable'd, see after
+    ---@type EntityPlayer[]
+    sharedVars.Players = {}
+end
 
---[[
-    Was:
-    local game / StageAPI.Game
-    local sfx
-    local room / StageAPI.Room
-    local level / StageAPI.Level
-    local players / StageAPI.Players
-]]
+setmetatable(sharedVars, {
+    __index = function(self, key)
+        if key == "Players" then
+            -- Do not actually keep players in memory to avoid crashes
+            -- and running it in a callback risked players being nil
+            -- for things that run before it in a run, or invalid for 
+            -- things that run before it in general
+            return StageAPI.GetPlayers()
+        end
+    end
+})
 
 return sharedVars


### PR DESCRIPTION
Add `StageAPI.SaveTableMarshal` (and `StageAPI.SaveTableUnmarshal`) to convert some save values to be better handled by json (or handled in general). Handles:
- Int tables, to avoid mods having to do it at runtime to prevent big json files
- Vectors, are turned into a simple two-item table
StageAPI saves use it, and the function is in the StageAPI table for mods to use too.

Also, improved the triggers for saving data (fixing Genesis teleports), and made shared.Players a metatable thing.