### PR TITLE
Fix custom stages not passing a RoomDescriptor when selecting a boss

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -579,7 +579,7 @@ function StageAPI.GenerateBossRoom(bossID, checkEncountered, bosses, hasHorseman
 
     local bossID = args.BossID
     if not bossID then
-        bossID = StageAPI.SelectBoss(args.Bosses)
+        bossID = StageAPI.SelectBoss(args.Bosses, nil, roomArgs.RoomDescriptor, false)
     elseif args.CheckEncountered then
         if StageAPI.GetBossEncountered(bossID) then
             StageAPI.LogErr("Trying to generate boss room for encountered boss: " .. tostring(bossID))


### PR DESCRIPTION
This caused stuff like AlwaysUseSubType/OnlyUseSubType to not work on custom stages