### PR TITLE
Update shared vars earlier with Repentogon

### DIFF
--- a/scripts/stageapi/basic.lua
+++ b/scripts/stageapi/basic.lua
@@ -268,7 +268,16 @@ function StageAPI.GetPlayers()
     return players
 end
 
-mod:AddPriorityCallback(ModCallbacks.MC_POST_NEW_ROOM, CallbackPriority.IMPORTANT, function()
-    shared.Level = shared.Game:GetLevel()
-    shared.Room = shared.Game:GetRoom()
-end)
+if REPENTOGON then 
+    mod:AddPriorityCallback(ModCallbacks.MC_PRE_NEW_ROOM, CallbackPriority.IMPORTANT, function(_, room, roomDesc)
+        shared.Room = room
+    end)
+    mod:AddPriorityCallback(ModCallbacks.MC_POST_NEW_ROOM, CallbackPriority.IMPORTANT, function()
+        shared.Level = shared.Game:GetLevel()
+    end)
+else
+    mod:AddPriorityCallback(ModCallbacks.MC_POST_NEW_ROOM, CallbackPriority.IMPORTANT, function()
+        shared.Level = shared.Game:GetLevel()
+        shared.Room = shared.Game:GetRoom()
+    end)
+end

--- a/scripts/stageapi/room/roomHandler.lua
+++ b/scripts/stageapi/room/roomHandler.lua
@@ -1184,8 +1184,10 @@ function StageAPI.GetCurrentRoomID()
     local levelMap = StageAPI.GetCurrentLevelMap()
     if levelMap and StageAPI.CurrentLevelMapRoomID then
         return levelMap:GetRoomData(StageAPI.CurrentLevelMapRoomID).RoomID
-    else
+    elseif shared.Level then
         return StageAPI.GetCurrentListIndex()
+    else -- level not init (early-triggering repentogon callbacks)
+        error("StageAPI: tried accessing room ID before level init", 2)
     end
 end
 
@@ -1296,6 +1298,10 @@ function StageAPI.SetCurrentRoom(room)
 end
 
 function StageAPI.GetCurrentRoom()
+    -- level not init (early repentogon callbacks)
+    if not shared.Level then
+        return nil
+    end
     return StageAPI.GetLevelRoom(StageAPI.GetCurrentRoomID())
 end
 

--- a/scripts/stageapi/shared.lua
+++ b/scripts/stageapi/shared.lua
@@ -8,9 +8,9 @@ sharedVars.Music = MusicManager()
 sharedVars.ItemConfig = Isaac.GetItemConfig()
  -- for autocomplete, set by basic.lua
 ---@type Room
-sharedVars.Room = room
+sharedVars.Room = nil
 ---@type Level
-sharedVars.Level = level
+sharedVars.Level = nil
 if false then -- for vscode autocompletion, do not actually run as it gets metatable'd, see after
     ---@type EntityPlayer[]
     sharedVars.Players = {}


### PR DESCRIPTION
As some Repentogon callbacks might trigger early, check for room/level to be initialized and init them earlier