### PR TITLE
Serialization & log tweaks

### DIFF
--- a/scripts/stageapi/basic.lua
+++ b/scripts/stageapi/basic.lua
@@ -29,14 +29,22 @@ end
 
 function StageAPI.LogErr(...)
     local str = StageAPI.LogConcat('[StageAPI:ERROR] ', ...)
-    Isaac.ConsoleOutput(str .. '\n')
+    if REPENTOGON then
+        Console.PrintError(str)
+    else
+        Isaac.ConsoleOutput(str .. '\n')
+    end
     Isaac.DebugString(str)
 end
 
 function StageAPI.LogWarn(...)
     local str = StageAPI.LogConcat('[StageAPI:WARNING] ', ...)
     if StageAPI.DebugMinorLog then
-        Isaac.ConsoleOutput(str .. "\n")
+        if REPENTOGON then
+            Console.PrintWarning(str)
+        else
+            Isaac.ConsoleOutput(str .. "\n")
+        end
     end
     Isaac.DebugString(str)
 end

--- a/scripts/stageapi/basic.lua
+++ b/scripts/stageapi/basic.lua
@@ -8,9 +8,11 @@ Isaac.DebugString("[StageAPI] Loading Core Definitions")
 StageAPI.DebugMinorLog = false
 
 function StageAPI.LogConcat(prefix, ...)
+    -- len allows this to work with nil values in the vararg
+    local args, len = {...}, select("#", ...)
     local str = prefix
-    local args = {...}
-    for i, arg in ipairs(args) do
+    for i=1, len do
+        local arg = args[i]
         str = str .. tostring(arg)
 
         if i ~= #args and type(arg) ~= "string" then

--- a/scripts/stageapi/library/pits.lua
+++ b/scripts/stageapi/library/pits.lua
@@ -65,7 +65,7 @@ local AdjacentAdjustments = {
     {X = 1, Y = 1}
 }
 
-function StageAPI.GetPitFramesFromIndices(indices, width, height, hasExtraFrames)
+function StageAPI.GetPitFramesFromIndices(indices, width, height, hasExtraFrames, noStringify)
     local frames = {}
     for index, _ in pairs(indices) do
         local x, y = StageAPI.GridToVector(index, width)
@@ -84,7 +84,8 @@ function StageAPI.GetPitFramesFromIndices(indices, width, height, hasExtraFrames
             end
         end
         adjIndices[#adjIndices + 1] = hasExtraFrames
-        frames[tostring(index)] = StageAPI.GetPitFrame(table.unpack(adjIndices))
+        local key = noStringify and index or tostring(index)
+        frames[key] = StageAPI.GetPitFrame(table.unpack(adjIndices))
     end
 
     return frames


### PR DESCRIPTION
Assorted minor changes
- Arg to disable index stringification for GetPitFramesFromIndices, in case it's passed to save tables handled by StageAPI that already manages int-tables (needed by Revelations)
- Use Repentogon to console-log error/warns if available
- Improve LogConcat to handle nil values
- RandomWeight verbosely errors when the total weight is zero