### PR TITLE
Fix grids unloading when using the D7

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1445,8 +1445,10 @@ StageAPI.AddCallback("StageAPI", Callbacks.EARLY_NEW_ROOM, -1, function()
         end
     end
 
-    for _, customGrid in ipairs(StageAPI.GetCustomGrids()) do
-        customGrid:Unload()
+    if not StageAPI.JustUsedD7 then
+        for _, customGrid in ipairs(StageAPI.GetCustomGrids()) do
+            customGrid:Unload()
+        end
     end
 
     if StageAPI.InTestMode then


### PR DESCRIPTION
Testing some FF grids with this change and everything seemed fine, but unsure if this change has any ramifications.

Also a workshop release sometime soon would be really nice :)