### PR TITLE
Don't override the boss room in the April's Fool challenge

### DIFF
--- a/scripts/stageapi/stage/bosses.lua
+++ b/scripts/stageapi/stage/bosses.lua
@@ -588,7 +588,7 @@ function StageAPI.SelectBoss(bosses, rng, roomDesc, ignoreNoOptions)
         bossID = nil
     end
 
-    if bossID and type(bossID) == "boolean" then
+    if Isaac.GetChallenge() == Challenge.CHALLENGE_APRILS_FOOL or (bossID and type(bossID) == "boolean") then
         return nil, true
     elseif not bossID then
         roomDesc = roomDesc or shared.Level:GetCurrentRoomDesc()


### PR DESCRIPTION
Currently bosses added to spawn through Stage API can appear during the April's Fool challenge. The challenge should always spawn the bloat in every boss room, so I just prevent a boss from being picked if the challenge is being played. If someone really wants to add a boss to the aprils fool challenge there are other ways (look at the boss butch mod), so I believe this method is fine.