### PR TITLE
Fix level music not starting immediately if skipping the transition for custom stages

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1159,7 +1159,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
         if StageAPI.CurrentStage and StageAPI.CurrentStage.GetPlayingMusic then
             local musicID = StageAPI.CurrentStage:GetPlayingMusic()
             if musicID then
-                shared.Music:Queue(musicID)
+                shared.Music:Crossfade(musicID)
             end
         end
     end


### PR DESCRIPTION
Very simple fix, just needs to be crossfaded instead of queued