### PR TITLE
Room loading is now deferred to MC_POST_NEW_LEVEL

### DIFF
--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -172,7 +172,7 @@ function StageAPI.CustomStage:WillOverrideRoom(roomDesc)
         return true
     elseif isStartingRoom and self.StartingRooms then
         return true
-    elseif self.Rooms[rtype] then
+    elseif self.Rooms and self.Rooms[rtype] then
         local rooms = self.Rooms[rtype]
         local subtype = roomDesc.Data.Subtype
         if rooms.Default or (rooms.Subtypes and rooms.Subtypes[subtype]) then


### PR DESCRIPTION
Room loading is deferred to MC_POST_NEW_LEVEL in order to prevent the "No layout!" bug when loading rooms with stageapi entities that aren't a part of a custom stage.

Tested on custom stages (Mortis and the Future, but do note the Future has its own bug where Steven beggar rooms can sometimes replace rooms on exit and continue) and normal stages (Fiend Folio). Since this deals with save data, I'd appreciate if more testing could be done.