### PR TITLE
Add Blue Key rooms to default StageMusic list

### DIFF
--- a/scripts/stageapi/stage/customstage.lua
+++ b/scripts/stageapi/stage/customstage.lua
@@ -239,7 +239,8 @@ function StageAPI.CustomStage:SetStageMusic(music)
         RoomType.ROOM_SACRIFICE,
         RoomType.ROOM_DICE,
         RoomType.ROOM_CHEST,
-        RoomType.ROOM_DUNGEON
+        RoomType.ROOM_DUNGEON,
+        RoomType.ROOM_BLUE,
     })
 end
 


### PR DESCRIPTION
The base stages have normal music in these rooms, so the RoomType.ROOM_BLUE rooms should use the default stage music