### PR TITLE
Fix Blue Womb Entrance Sprite

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -276,8 +276,11 @@ function StageAPI.CheckStageTrapdoor(grid, index)
     local currStage = StageAPI.CurrentStage or {}
     
     local isBlueWomb = StageAPI.IsBlueWombEntranceRoom()
+    local enteringBlueWomb = false 
     local nextStage
+
     if isBlueWomb and currStage.StageHPNumber == LevelStage.STAGE4_2 then
+        enteringBlueWomb = true 
         nextStage = {
             NormalStage = true,
             Stage = LevelStage.STAGE4_3,
@@ -290,7 +293,7 @@ function StageAPI.CheckStageTrapdoor(grid, index)
         end
     end
 
-    if nextStage and not currStage.OverridingTrapdoors then
+    if not enteringBlueWomb and nextStage and not currStage.OverridingTrapdoors then
         StageAPI.SpawnCustomTrapdoor(shared.Room:GetGridPosition(index), nextStage, grid:GetSprite():GetFilename(), 20, true)
         shared.Room:RemoveGridEntity(index, 0, false)
     end


### PR DESCRIPTION
Currently, when entering the Blue Womb entrance, StageAPI spawns a custom trapdoor on top of the Blue Womb trapdoor with the normal womb trapdoor. While the player still enters Blue Womb just fine, this is a jarring visual bug.

This fix is rather simple though I wish to get input on if preventing the trapdoor from spawning is a good idea since I'm not 100% sure if this is happening for a good reason. If a custom trapdoor is needed, I could just opt to change the custom trapdoor's sprite into the Blue Womb sprite instead.