### PR TITLE
Support for Repentance+ themed 1% drops

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1561,6 +1561,204 @@ if REPENTOGON then
     end)
 end
 
+--#region Themed boss drops
+if REPENTANCE_PLUS then
+
+local function getBossDropPosition(idx, amount)
+    local room = shared.Game:GetRoom()
+
+    local NORMAL_IDX = 97
+
+    local startPos
+    if amount == 3 then
+        if idx == 1 then
+            startPos = room:GetGridPosition(95)
+        elseif idx == 2 then
+            startPos = room:GetGridPosition(NORMAL_IDX)
+        else
+            startPos = room:GetGridPosition(99)
+        end
+    elseif amount == 2 then
+        if idx == 1 then
+            startPos = room:GetGridPosition(96)
+        else
+            startPos = room:GetGridPosition(98)
+        end
+    else
+        startPos = room:GetGridPosition(NORMAL_IDX)
+    end
+
+    return room:FindFreeTilePosition(startPos, 0)
+end
+
+local BOSS_ITEM_OPTIONS_IDX = 3
+local repositionBossItems, bossItemsToPosition = false, 0
+local customThemedDropToSpawn = {}
+local skipRemainingDrops = false
+
+-- Handle themed boss drops
+---@param pickup EntityPickup
+mod:AddCallback(ModCallbacks.MC_POST_PICKUP_UPDATE, function (_, pickup)
+    -- Don't let this trigger on room enter, game continue, more than once, or for non trinkets/collectibles
+    local room = shared.Game:GetRoom()
+    local frame = room:GetFrameCount()
+    local currentRoom = StageAPI.GetCurrentRoom()
+    if (
+        pickup.FrameCount ~= 1
+        or room:GetFrameCount() == 0
+        or (currentRoom and currentRoom.BossDropFrame > frame)
+    ) then
+        return
+    end
+
+    -- If we're currently in a StageAPI boss room
+    if currentRoom and currentRoom.RoomType == RoomType.ROOM_BOSS and room:IsClear() then
+        local data = pickup:GetData()
+        if data.StageAPIDontCheckThemedDrop then
+            return
+        end
+
+        -- Check to see if a stageapi themed drop should spawn
+        local persistentData = currentRoom.PersistentData
+        local bossId = persistentData.BossID
+
+
+        if not skipRemainingDrops and (pickup.OptionsPickupIndex == BOSS_ITEM_OPTIONS_IDX or pickup.Variant == PickupVariant.PICKUP_TRINKET) then
+            -- Check our room's subtype and get what the ORIGINAL themed drop will be (IF IT EXISTS)
+            local level = shared.Game:GetLevel()
+            local roomSub = level:GetCurrentRoomDesc().Data.Subtype
+            if StageAPI.IsThemedBossDrop(pickup.Variant, pickup.SubType, roomSub) then
+                -- Remove the poof
+                for _, poof in ipairs(Isaac.FindByType(EntityType.ENTITY_EFFECT, EffectVariant.POOF01, 0)) do
+                    if poof.Position:Distance(pickup.Position) < 20 then
+                        poof:Remove()
+                    end
+                end
+
+                -- Kill the item.
+                pickup:Remove()
+
+                -- Don't let other items get removed on the incredibly low chance there are two of the same item
+                skipRemainingDrops = true
+
+                -- Queue all drops to be positioned on the next frame
+                repositionBossItems = true
+            end
+
+        end
+
+        -- Only run this check once
+        if bossId and currentRoom.BossDropFrame == -1 then
+            local bossData = StageAPI.GetBossData(bossId)
+            if bossData.ThemedItem or bossData.ThemedTrinket then
+                -- Roll to see if we should spawn it
+                local rng = RNG()
+                rng:SetSeed(currentRoom.AwardSeed, 35)
+
+                -- Check if stageapi should spawn a drop
+                local DROP_CHANCE = 1
+                if rng:RandomFloat() < DROP_CHANCE then
+                    local dropToSpawn = bossData.ThemedItem or bossData.ThemedTrinket
+                    local isTrinket = not bossData.ThemedItem
+                    customThemedDropToSpawn = {dropToSpawn, isTrinket}
+
+                    -- Mark all new pickups as an options pickup
+                    for _, ent in ipairs(Isaac.FindByType(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE)) do
+                        if ent.FrameCount == 1 then
+                            ent:ToPickup().OptionsPickupIndex = BOSS_ITEM_OPTIONS_IDX
+                        end
+                    end
+
+                    -- Queue all drops to be positioned on the next frame
+                    repositionBossItems = true
+                end
+            end
+
+            -- We have our boss drop
+            -- Set the boss drop frame and handle the item pedestal
+            currentRoom.BossDropFrame = frame
+        end
+
+    end
+end)
+
+mod:AddCallback(ModCallbacks.MC_POST_UPDATE, function ()
+    -- Reset this (happens after pickup updates are all done)
+    skipRemainingDrops = false
+
+    -- Spawn custom boss drops
+    local toPosition = bossItemsToPosition
+    local themedTrinket
+    if #customThemedDropToSpawn > 0 then
+        local dropToSpawn, isTrinket = table.unpack(customThemedDropToSpawn)
+        if isTrinket then
+            themedTrinket = Isaac.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_TRINKET, dropToSpawn, Vector.Zero, Vector.Zero, nil)
+        else
+            local item = Isaac.Spawn(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE, dropToSpawn, Vector.Zero, Vector.Zero, nil):ToPickup()
+            item.OptionsPickupIndex = BOSS_ITEM_OPTIONS_IDX
+
+            -- Mark it to not trigger the effect
+            item:GetData().StageAPIDontCheckThemedDrop = true
+        end
+
+        customThemedDropToSpawn = {}
+    end
+
+
+    -- Reposition the items in the room
+    if repositionBossItems then
+        local collectibles = Isaac.FindByType(EntityType.ENTITY_PICKUP, PickupVariant.PICKUP_COLLECTIBLE)
+
+        if themedTrinket then
+            toPosition = toPosition + 1
+        end
+
+        -- Get the total amount to position
+        for _, ent in ipairs(collectibles) do
+            local pickup = ent:ToPickup()
+            if pickup and pickup.OptionsPickupIndex == BOSS_ITEM_OPTIONS_IDX then
+                toPosition = toPosition + 1
+
+                -- Remove any poofs
+                for _, poof in ipairs(Isaac.FindByType(EntityType.ENTITY_EFFECT, EffectVariant.POOF01, 0)) do
+                    if poof.Position:Distance(pickup.Position) < 20 then
+                        poof:Remove()
+                    end
+                end
+            end
+        end
+
+        -- Position using total
+        local index = 0
+        for _, ent in ipairs(collectibles) do
+            local pickup = ent:ToPickup()
+            if pickup and pickup.OptionsPickupIndex == BOSS_ITEM_OPTIONS_IDX then
+                index = index + 1
+
+                local newPosition = getBossDropPosition(index, toPosition)
+                ent.TargetPosition = newPosition
+
+                -- Spawn new poofs
+                Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.POOF01, 0, newPosition, Vector.Zero, pickup)
+            end
+        end
+
+        -- Also move trinket if necessary
+        if themedTrinket then
+            local newPosition = getBossDropPosition(toPosition, toPosition)
+            themedTrinket.Position = newPosition
+
+            -- Spawn new poofs
+            Isaac.Spawn(EntityType.ENTITY_EFFECT, EffectVariant.POOF01, 0, newPosition, Vector.Zero, themedTrinket)
+        end
+
+        repositionBossItems = false
+        bossItemsToPosition = 0
+    end
+end)
+
+end
+
 --#region MemberCard
 
 local SECRET_SHOP_LADDER_VARIANT = 2

--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1656,7 +1656,7 @@ mod:AddCallback(ModCallbacks.MC_POST_PICKUP_UPDATE, function (_, pickup)
                 rng:SetSeed(currentRoom.AwardSeed, 35)
 
                 -- Check if stageapi should spawn a drop
-                local DROP_CHANCE = 1
+                local DROP_CHANCE = 0.01
                 if rng:RandomFloat() < DROP_CHANCE then
                     local dropToSpawn = bossData.ThemedItem or bossData.ThemedTrinket
                     local isTrinket = not bossData.ThemedItem

--- a/scripts/stageapi/library.lua
+++ b/scripts/stageapi/library.lua
@@ -13,6 +13,7 @@ local subModules = {
     "pauseDetection",
 	"deadendDetection",
     "lockedEntity",
+    "themedDrop",
 }
 
 for _, subModule in ipairs(subModules) do

--- a/scripts/stageapi/library/themedDrop.lua
+++ b/scripts/stageapi/library/themedDrop.lua
@@ -107,7 +107,27 @@ local ThemedDrops = {
 	-- Cadavra
 }
 
--- Check if the given pickup is a themed drop for the current room
+local WormTrinkets = {
+    TrinketType.TRINKET_PULSE_WORM,
+    TrinketType.TRINKET_RING_WORM,
+    TrinketType.TRINKET_TAPE_WORM,
+    TrinketType.TRINKET_WHIP_WORM,
+    TrinketType.TRINKET_WIGGLE_WORM,
+    TrinketType.TRINKET_FLAT_WORM,
+    TrinketType.TRINKET_HOOK_WORM,
+    TrinketType.TRINKET_LAZY_WORM,
+    TrinketType.TRINKET_OUROBOROS_WORM,
+    TrinketType.TRINKET_BRAIN_WORM,
+    TrinketType.TRINKET_RAINBOW_WORM,
+}
+
+-- Register worm trinkets for 1% themed drops
+-- Does NOT make it spawn from non-stageapi themed boss drops
+function StageAPI.RegisterWormTrinket(trinketId)
+    table.insert(WormTrinkets, trinketId)
+end
+
+-- Check if the given pickup is a VANILLA themed drop for the given vanilla boss
 function StageAPI.IsThemedBossDrop(variant, subType, roomSubType)
 	local entry = ThemedDrops[roomSubType]
 
@@ -116,6 +136,16 @@ function StageAPI.IsThemedBossDrop(variant, subType, roomSubType)
 
 		if (variant == PickupVariant.PICKUP_COLLECTIBLE and not isTrinket)
 		or (variant == PickupVariant.PICKUP_TRINKET 	   and 	   isTrinket) then
+            if isTrinket and entry[1] == -1 then
+                for _, worm in ipairs(WormTrinkets) do
+                    if subType == worm then
+                        return true
+                    end
+                end
+
+                return false
+            end
+
 			return subType == entry[1]
 		end
 	end

--- a/scripts/stageapi/library/themedDrop.lua
+++ b/scripts/stageapi/library/themedDrop.lua
@@ -1,0 +1,123 @@
+-- Boss Subtype = { id, isTrinket }
+-- -1 is a random worm trinket
+
+local ThemedDrops = {
+	[1] = { CollectibleType.COLLECTIBLE_MONSTROS_TOOTH, }, -- Monstro
+	[2] = { -1, true }, -- Larry Jr.
+	[3] = { CollectibleType.COLLECTIBLE_LITTLE_CHUBBY, }, -- Chub
+	[4] = { CollectibleType.COLLECTIBLE_LIL_GURDY, }, -- Gurdy
+	[5] = { CollectibleType.COLLECTIBLE_MONSTROS_LUNG, }, -- Monstro II
+	-- Mom
+	[7] = { -1, true }, -- Scolex
+	-- Mom's Heart
+	[9] = { TrinketType.TRINKET_LOCUST_OF_FAMINE, true }, -- Famine
+	[10] = { TrinketType.TRINKET_LOCUST_OF_PESTILENCE, true }, -- Pestilence
+	[11] = { TrinketType.TRINKET_LOCUST_OF_WRATH, true }, -- War
+	[12] = { TrinketType.TRINKET_LOCUST_OF_DEATH, true }, -- Death
+	[13] = { CollectibleType.COLLECTIBLE_HALO_OF_FLIES, }, -- Duke of Flies
+	[14] = { CollectibleType.COLLECTIBLE_FREE_LEMONADE, }, -- Peep
+	[15] = { CollectibleType.COLLECTIBLE_LOKIS_HORNS, }, -- Loki
+	[16] = { CollectibleType.COLLECTIBLE_LIL_SPEWER, }, -- Blastocyst
+	[17] = { CollectibleType.COLLECTIBLE_GEMINI, }, -- Gemini
+	[18] = { CollectibleType.COLLECTIBLE_LEPROSY, }, -- Fistula
+	-- Gish
+	-- Steven
+	-- C.H.A.D.
+	-- Headless Horseman
+	[23] = { CollectibleType.COLLECTIBLE_BRIMSTONE_BOMBS, }, -- The Fallen
+	-- Satan
+	-- It Lives
+	[26] = { -1, true }, -- The Hollow
+	[27] = { CollectibleType.COLLECTIBLE_BONE_SPURS, }, -- Carrion Queen
+	[28] = { CollectibleType.COLLECTIBLE_LIL_GURDY, }, -- Gurdy Jr.
+	[29] = { CollectibleType.COLLECTIBLE_INFESTATION, }, -- The Husk
+	[30] = { CollectibleType.COLLECTIBLE_PEEPER, }, -- The Bloat
+	[31] = { CollectibleType.COLLECTIBLE_LIL_LOKI, }, -- Lokii
+	[32] = { CollectibleType.COLLECTIBLE_LOST_SOUL, }, -- Blighted Ovum
+	[33] = { CollectibleType.COLLECTIBLE_TINYTOMA, }, -- Teratoma
+	[34] = { CollectibleType.COLLECTIBLE_SPIDERBABY, }, -- The Widow
+	[35] = { CollectibleType.COLLECTIBLE_INFAMY, }, -- Mask of Infamy
+	[36] = { CollectibleType.COLLECTIBLE_JUICY_SACK, }, -- The Wretched
+	[37] = { -1, true }, -- Pin
+	[38] = { TrinketType.TRINKET_LOCUST_OF_CONQUEST, true }, -- Conquest
+	-- Isaac
+	-- ???
+	[41] = { CollectibleType.COLLECTIBLE_DADDY_LONGLEGS, }, -- Daddy Long Legs
+	[42] = { CollectibleType.COLLECTIBLE_SPIDER_BITE, }, -- Triachnid
+	[43] = { CollectibleType.COLLECTIBLE_LIL_HAUNT, }, -- The Haunt
+	[44] = { CollectibleType.COLLECTIBLE_POOP, }, -- Dingle
+	[45] = { CollectibleType.COLLECTIBLE_CONTINUUM, }, -- Mega Maw
+	[46] = { CollectibleType.COLLECTIBLE_HOST_HAT, }, -- The Gate
+	[47] = { CollectibleType.COLLECTIBLE_THUNDER_THIGHS, }, -- Mega Fatty
+	[48] = { CollectibleType.COLLECTIBLE_BIRD_CAGE, }, -- The Cage
+	[49] = { CollectibleType.COLLECTIBLE_LIL_GURDY, }, -- Mama Gurdy
+	[50] = { CollectibleType.COLLECTIBLE_DARK_MATTER, }, -- Dark One
+	[51] = { CollectibleType.COLLECTIBLE_EYE_OF_THE_OCCULT, }, -- Adversary
+	[52] = { CollectibleType.COLLECTIBLE_GIANT_CELL, }, -- Polycephalus
+	[53] = { CollectibleType.COLLECTIBLE_HARLEQUIN_BABY, }, -- Mr. Fred
+	-- The Lamb
+	-- Mega Satan
+	[56] = { CollectibleType.COLLECTIBLE_LIL_GURDY, }, -- Gurglings
+	[57] = { CollectibleType.COLLECTIBLE_WORM_FRIEND, }, -- The Stain
+	[58] = { CollectibleType.COLLECTIBLE_DIRTY_MIND, }, -- Brownie
+	[59] = { CollectibleType.COLLECTIBLE_BOOK_OF_THE_DEAD, }, -- The Forsaken
+	[60] = { CollectibleType.COLLECTIBLE_LITTLE_HORN, }, -- Little Horn
+	[61] = { CollectibleType.COLLECTIBLE_BOX_OF_SPIDERS, }, -- Rag Man
+	-- Ultra Greed
+	-- Hush
+	[64] = { CollectibleType.COLLECTIBLE_MONTEZUMAS_REVENGE, }, -- Dangle
+	[65] = { CollectibleType.COLLECTIBLE_NUMBER_TWO, }, -- Turdlings
+	[66] = { CollectibleType.COLLECTIBLE_BRITTLE_BONES, }, -- The Frail
+	[67] = { CollectibleType.COLLECTIBLE_SPOON_BENDER, }, -- Rag Mega
+	[68] = { CollectibleType.COLLECTIBLE_GIMPY, }, -- Sisters Vis
+	[69] = { CollectibleType.COLLECTIBLE_LITTLE_HORN, }, -- Big Horn
+	-- Delirium
+	-- Ultra Greedier
+	[72] = { CollectibleType.COLLECTIBLE_BIG_CHUBBY, }, -- The Matriarch
+	[73] = { CollectibleType.COLLECTIBLE_COMPOUND_FRACTURE, }, -- The Pile
+	[74] = { CollectibleType.COLLECTIBLE_THE_WIZ, }, -- Reap Creep
+	[75] = { CollectibleType.COLLECTIBLE_AQUARIUS, }, -- Lil Blub
+	[76] = { CollectibleType.COLLECTIBLE_LEECH, }, -- Wormwood
+	[77] = { CollectibleType.COLLECTIBLE_DEPRESSION, }, -- Rainmaker
+	[78] = { CollectibleType.COLLECTIBLE_EMPTY_HEART, }, -- The Visage
+	[79] = { TrinketType.TRINKET_FORGOTTEN_LULLABY, true }, -- The Siren
+	[80] = { CollectibleType.COLLECTIBLE_TOOTH_AND_NAIL, }, -- Tuff Twins
+	[81] = { CollectibleType.COLLECTIBLE_CEREMONIAL_ROBES, }, -- The Heretic
+	[82] = { CollectibleType.COLLECTIBLE_HOT_BOMBS, }, -- Hornfel
+	[83] = { CollectibleType.COLLECTIBLE_GNAWED_LEAF, }, -- Great Gideon
+	-- Baby Plum
+	[85] = { CollectibleType.COLLECTIBLE_MAGIC_SKIN, }, -- The Scourge
+	[86] = { CollectibleType.COLLECTIBLE_DECAP_ATTACK, }, -- Chimera
+	[87] = { CollectibleType.COLLECTIBLE_YUCK_HEART, }, -- Rotgut
+	-- Mother
+	-- Mausoleum Mom
+	-- Mausoleum Mom's Heart
+	[91] = { CollectibleType.COLLECTIBLE_SMART_FLY, }, -- Min-Min
+	[92] = { CollectibleType.COLLECTIBLE_FLUSH, }, -- Clog
+	[93] = { CollectibleType.COLLECTIBLE_BIRDS_EYE, }, -- Singe
+	-- Bumbino
+	[95] = { CollectibleType.COLLECTIBLE_BUTT_BOMBS, }, -- Colostomia
+	[96] = { CollectibleType.COLLECTIBLE_AKELDAMA, }, -- The Shell
+	[97] = { CollectibleType.COLLECTIBLE_BROWN_NUGGET, }, -- Turdlet
+	-- Raglich
+	-- Dogma
+	-- The Beast
+	[101] = { TrinketType.TRINKET_THE_TWINS, true }, -- Horny Boys
+	[102] = { CollectibleType.COLLECTIBLE_ASTRAL_PROJECTION, }, -- Clutch
+	-- Cadavra
+}
+
+-- Check if the given pickup is a themed drop for the current room
+function StageAPI.IsThemedBossDrop(variant, subType, roomSubType)
+	local entry = ThemedDrops[roomSubType]
+
+	if entry then
+		local isTrinket = entry[2]
+
+		if (variant == PickupVariant.PICKUP_COLLECTIBLE and not isTrinket)
+		or (variant == PickupVariant.PICKUP_TRINKET 	   and 	   isTrinket) then
+			return subType == entry[1]
+		end
+	end
+	return false
+end

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -126,6 +126,7 @@ end
 ---@field JustCleared boolean
 ---@field IsPersistentRoom boolean
 ---@field Layout RoomLayout
+---@field BossDropFrame integer #The room frame the boss dropped its item on, or -1 if not dropped yet. Only set in Repentance+
 StageAPI.LevelRoom = StageAPI.Class("LevelRoom")
 StageAPI.NextUniqueRoomIdentifier = 0
 function StageAPI.LevelRoom:Init(args, ...)
@@ -168,6 +169,7 @@ function StageAPI.LevelRoom:Init(args, ...)
         self.Doors = self.Doors or (roomDesc and StageAPI.GetDoorsForRoomFromData(roomDesc.Data)) or StageAPI.Copy(StageAPI.AllDoorsOpen)
         self.VisitCount = self.VisitCount or (roomDesc and roomDesc.VisitedCount) or 0
         self.ClearCount = self.ClearCount or (roomDesc and roomDesc.ClearCount) or 0
+        self.BossDropFrame = -1
 
         self.Dimension = self.Dimension or StageAPI.GetDimension(roomDesc)
 
@@ -657,7 +659,7 @@ local saveDataCopyDirectly = {
     "IsClear","WasClearAtStart","RoomsListName","RoomsListID","LayoutName","SpawnSeed","AwardSeed","DecorationSeed",
     "FirstLoad","Shape","RoomType","TypeOverride","PersistentData","IsExtraRoom","LastPersistentIndex",
     "RequireRoomType", "IgnoreRoomRules", "VisitCount", "ClearCount", "LevelIndex","HasWaterPits","ChallengeDone",
-    "SurpriseMiniboss", "FromData", "Dimension", "NoChampions",
+    "SurpriseMiniboss", "FromData", "Dimension", "NoChampions", "BossDropFrame",
 }
 
 function StageAPI.LevelRoom:GetSaveData(isExtraRoom)

--- a/scripts/stageapi/stage/bosses.lua
+++ b/scripts/stageapi/stage/bosses.lua
@@ -517,6 +517,8 @@ end)
 ---@field Rooms RoomsList
 ---@field Shapes RoomShape[]
 ---@field BaseGameBoss boolean
+---@field ThemedItem number? Themed item drop (Repentance+ feature). Leave nil for no drop
+---@field ThemedTrinket number? Themed trinket drop (Repentance+ feature). Leave nil for no drop, ThemedItem takes priority.
 
 ---@type table<string, BossData>
 StageAPI.Bosses = {}


### PR DESCRIPTION
I couldn't manage to test if it correctly deletes the vanilla themed drop when it's a trinket that the stageapi boss overwrote but i tested every other circumstance and it all works.