### PR TITLE
Use REPENTOGON (if available) to load RoomConfig data on startup as opposed to using "goto" on run start

### DIFF
--- a/scripts/stageapi/stage/extrarooms.lua
+++ b/scripts/stageapi/stage/extrarooms.lua
@@ -106,6 +106,25 @@ function StageAPI.PreloadGotoRooms(roomTypes, roomShapes)
         end
 
         for _, roomShape in ipairs(roomShapes) do
+            if REPENTOGON and RoomConfig then
+                local stbType = roomType == RoomType.ROOM_DEFAULT and StbType.BASEMENT or StbType.SPECIAL_ROOMS
+                local shapeData = StageAPI.RoomShapeToGotoData[roomShape]
+
+                local ID = math.tointeger(shapeData.ID)
+                if ID then
+                    local room = RoomConfig.GetRoomByStageTypeAndVariant(stbType, roomType, ID, 0)
+                    if room then
+                        shapes[roomShape] = true
+                        shapeData.Data[roomType] = room
+                    end
+                end
+
+                local lockedID = math.tointeger(shapeData.Locked)
+                if lockedID then
+                    shapeData.LockedData[roomType] = RoomConfig.GetRoomByStageTypeAndVariant(stbType, roomType, ID, 0) or {}
+                end
+            end
+
             if not shapes[roomShape] then
                 shapes[roomShape] = false
             end


### PR DESCRIPTION
Use REPENTOGON to handle room data preloading immediately, when possible. This removes the necessity of using "goto" to load room data, as well as restarting the run or moving the player back to the starting room.

Tested by verifying that the goto loading does not trigger, and playing around on the Grotto custom stage (in particular its tall boss rooms, including during ascent).