### PR TITLE
Fix custom grids that override vanilla drops checking every frame until something is removed instead of only for one frame

### DIFF
--- a/scripts/stageapi/grid/altRockOverride.lua
+++ b/scripts/stageapi/grid/altRockOverride.lua
@@ -44,6 +44,10 @@ mod:AddCallback(ModCallbacks.MC_PRE_ENTITY_SPAWN, function(_, id, variant, subty
     local customGrid = StageAPI.GetCustomGrid(grindex)
     local shouldOverride
 
+    if customGrid and customGrid.DestroyedFrame and shared.Game:GetFrameCount() > customGrid.DestroyedFrame then
+        return
+    end
+
     if customGrid and customGrid.GridConfig.OverrideGridSpawns and customGrid.GridEntity and not customGrid.CheckedForOverride then
         local breakstate = customGrid.GridConfig.OverrideGridSpawnsState or StageAPI.DefaultBrokenGridStateByType[customGrid.GridConfig.BaseType]
         if customGrid.GridEntity.State == breakstate then

--- a/scripts/stageapi/grid/altRockOverride.lua
+++ b/scripts/stageapi/grid/altRockOverride.lua
@@ -44,7 +44,12 @@ mod:AddCallback(ModCallbacks.MC_PRE_ENTITY_SPAWN, function(_, id, variant, subty
     local customGrid = StageAPI.GetCustomGrid(grindex)
     local shouldOverride
 
-    if customGrid and customGrid.DestroyedFrame and shared.Game:GetFrameCount() > customGrid.DestroyedFrame then
+    if (
+        customGrid
+        and customGrid.PersistentData
+        and customGrid.PersistentData.DestroyedFrame
+        and shared.Game:GetFrameCount() > customGrid.PersistentData.DestroyedFrame
+    ) then
         return
     end
 

--- a/scripts/stageapi/grid/customgrids.lua
+++ b/scripts/stageapi/grid/customgrids.lua
@@ -299,6 +299,7 @@ function StageAPI.CustomGridEntity:Update()
 
         if not self.PersistentData.Destroyed then
             self.PersistentData.Destroyed = true
+            self.DestroyedFrame = shared.Game:GetFrameCount()
             StageAPI.TemporaryIgnoreSpawnOverride = true
             self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_DESTROY)
             StageAPI.TemporaryIgnoreSpawnOverride = false
@@ -365,6 +366,7 @@ function StageAPI.CustomGridEntity:Update()
                             return
                         elseif self.GridEntity.State == StageAPI.DefaultBrokenGridStateByType[self.GridConfig.BaseType] and not self.PersistentData.Destroyed then
                             self.PersistentData.Destroyed = true
+                            self.DestroyedFrame = shared.Game:GetFrameCount()
                             StageAPI.TemporaryIgnoreSpawnOverride = true
                             self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_DESTROY)
                             StageAPI.TemporaryIgnoreSpawnOverride = false
@@ -402,6 +404,7 @@ function StageAPI.CustomGridEntity:UpdateProjectile(projectile)
     self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_PROJECTILE_UPDATE, projectile)
     if self.Projectile:IsDead() and not self.PersistentData.Destroyed then
         self.PersistentData.Destroyed = true
+        self.DestroyedFrame = shared.Game:GetFrameCount()
         self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_DESTROY, projectile)
     end
 

--- a/scripts/stageapi/grid/customgrids.lua
+++ b/scripts/stageapi/grid/customgrids.lua
@@ -299,7 +299,7 @@ function StageAPI.CustomGridEntity:Update()
 
         if not self.PersistentData.Destroyed then
             self.PersistentData.Destroyed = true
-            self.DestroyedFrame = shared.Game:GetFrameCount()
+            self.PersistentData.DestroyedFrame = shared.Game:GetFrameCount()
             StageAPI.TemporaryIgnoreSpawnOverride = true
             self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_DESTROY)
             StageAPI.TemporaryIgnoreSpawnOverride = false
@@ -366,7 +366,7 @@ function StageAPI.CustomGridEntity:Update()
                             return
                         elseif self.GridEntity.State == StageAPI.DefaultBrokenGridStateByType[self.GridConfig.BaseType] and not self.PersistentData.Destroyed then
                             self.PersistentData.Destroyed = true
-                            self.DestroyedFrame = shared.Game:GetFrameCount()
+                            self.PersistentData.DestroyedFrame = shared.Game:GetFrameCount()
                             StageAPI.TemporaryIgnoreSpawnOverride = true
                             self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_DESTROY)
                             StageAPI.TemporaryIgnoreSpawnOverride = false
@@ -404,7 +404,7 @@ function StageAPI.CustomGridEntity:UpdateProjectile(projectile)
     self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_PROJECTILE_UPDATE, projectile)
     if self.Projectile:IsDead() and not self.PersistentData.Destroyed then
         self.PersistentData.Destroyed = true
-        self.DestroyedFrame = shared.Game:GetFrameCount()
+        self.PersistentData.DestroyedFrame = shared.Game:GetFrameCount()
         self:CallCallbacks(Callbacks.POST_CUSTOM_GRID_DESTROY, projectile)
     end
 


### PR DESCRIPTION
Tested with a pot replacement and many Fiend Folio grids. It'll only remove things on the first frame of being destroyed instead of every frame until something is removed.