### PR TITLE
With REPENTOGON, use SetBackdropType instead of ShowHallucination

### DIFF
--- a/scripts/stageapi/stage/roomgfx.lua
+++ b/scripts/stageapi/stage/roomgfx.lua
@@ -154,8 +154,12 @@ end
 
 function StageAPI.ChangeBackdrop(backdrop, justWalls, storeBackdropEnts)
     if type(backdrop) == "number" then
-        shared.Game:ShowHallucination(0, backdrop)
-        shared.Sfx:Stop(SoundEffect.SOUND_DEATH_CARD)
+        if REPENTOGON then
+            shared.Room:SetBackdropType(backdrop, 1)
+        else
+            shared.Game:ShowHallucination(0, backdrop)
+            shared.Sfx:Stop(SoundEffect.SOUND_DEATH_CARD)
+        end
 
         return
     end


### PR DESCRIPTION
This prevents the death card sound from sometimes very briefly slipping through

Otherwise the behaviour is the same. Tested with Golem's Subway in Fiend Folio where I could often hear the first brief bit of the death card sound when entering.