### PR TITLE
Fix a couple issues related to quitting & continuing a run

### DIFF
--- a/scripts/stageapi/core/saveSystem.lua
+++ b/scripts/stageapi/core/saveSystem.lua
@@ -221,11 +221,17 @@ function StageAPI.LoadSaveString(str)
             retCustomGrids[dimension][lindex] = roomSaveData.CustomGrids
 
             if roomSaveData.Room then
-                StageAPI.RoomsToLoad[#StageAPI.RoomsToLoad+1] = {
-                    RoomSaveData = roomSaveData,
-                    Dimension = dimension,
-                    LIndex = lindex,
-                }
+                -- Defer loading rooms that require vanilla RoomDescriptor Data, as it is not available yet.
+                if roomSaveData.Room.FromData then
+                    StageAPI.RoomsToLoad[#StageAPI.RoomsToLoad+1] = {
+                        RoomSaveData = roomSaveData,
+                        Dimension = dimension,
+                        LIndex = lindex,
+                    }
+                else
+                    local customRoom = StageAPI.LevelRoom{FromSave = roomSaveData.Room}
+                    StageAPI.SetLevelRoom(customRoom, lindex, dimension)
+                end
             end
         end
     end

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -425,7 +425,11 @@ function StageAPI.LevelRoom:PostGetLayout(seed)
         end
 
         self.Layout = StageAPI.CreateEmptyRoomLayout(self.Shape)
-        StageAPI.LogErr("No layout!")
+        StageAPI.LogErr("No layout! ("
+            .. "Dimension: " .. (self.Dimension or "nil") .. ", "
+            .. "LevelIndex: " .. (self.LevelIndex or "nil") .. ", "
+            .. "RoomsListName: " .. (self.RoomsListName or "nil") .. ", "
+            .. "RoomsListID: " .. (self.RoomsListID or "nil") .. ")")
     end
 
     StageAPI.LogMinor("Initialized room " .. tostring(self.Layout.Name) .. "." .. tostring(self.Layout.Variant) .. " from file " .. tostring(self.Layout.RoomFilename)

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -664,7 +664,7 @@ local saveDataCopyDirectly = {
     "IsClear","WasClearAtStart","RoomsListName","RoomsListID","LayoutName","SpawnSeed","AwardSeed","DecorationSeed",
     "FirstLoad","Shape","RoomType","TypeOverride","PersistentData","IsExtraRoom","LastPersistentIndex",
     "RequireRoomType", "IgnoreRoomRules", "VisitCount", "ClearCount", "LevelIndex","HasWaterPits","ChallengeDone",
-    "SurpriseMiniboss", "FromData", "Dimension", "NoChampions", "BossDropFrame",
+    "SurpriseMiniboss", "FromData", "Dimension", "NoChampions", "BossDropFrame", "IgnoreShape", "IgnoreDoors",
 }
 
 function StageAPI.LevelRoom:GetSaveData(isExtraRoom)

--- a/scripts/stageapi/room/levelRoom.lua
+++ b/scripts/stageapi/room/levelRoom.lua
@@ -386,7 +386,8 @@ function StageAPI.LevelRoom:GetLayout()
             else
                 local requireSubtype, forceRequiredSubtype = GetRequiredLevelRoomSubtype(self)
                 local minDifficulty, maxDifficulty = GetDifficultyRange(self)
-                self.Layout = StageAPI.ChooseRoomLayout{
+
+                self.Layout, self.RoomsListID = StageAPI.ChooseRoomLayout{
                     RoomList = roomsList,
                     Seed = self.SpawnSeed,
                     IgnoreShape = self.IgnoreShape,

--- a/scripts/stageapi/room/roomHandler.lua
+++ b/scripts/stageapi/room/roomHandler.lua
@@ -198,17 +198,18 @@ end
 function StageAPI.GetValidRoomsForLayout(args)
     local roomList = args.RoomList
     local roomDesc = args.RoomDescriptor or shared.Level:GetCurrentRoomDesc()
-    local shape = -1
+    local requestedShape = -1
     if not args.IgnoreShape then
-        shape = args.Shape or (roomDesc.Data and roomDesc.Data.Shape or shape)
+        requestedShape = args.Shape or (roomDesc.Data and roomDesc.Data.Shape or shape)
     end
+
+    local allowedRoomShapes = (requestedShape == -1) and roomList.Shapes or {requestedShape}
 
     local callbacks = StageAPI.GetCallbacks(Callbacks.POST_CHECK_VALID_ROOM)
     local validRooms = {}
     local validRoomWeights = 0
 
-    local possibleRooms = roomList:GetRooms(shape)
-    if not possibleRooms then
+    if requestedShape ~= -1 and not roomList:GetRooms(requestedShape) then
         return {}, nil, "No rooms for shape!"
     end
 
@@ -226,62 +227,62 @@ function StageAPI.GetValidRoomsForLayout(args)
     local mindiff = args.MinDifficulty
     local maxdiff = args.MaxDifficulty
 
-    for listID, layout in ipairs(possibleRooms) do
-        shape = layout.Shape
+    for _, shape in ipairs(allowedRoomShapes) do
+        for listID, layout in ipairs(roomList:GetRooms(shape) or {}) do
+            local isValid = true
 
-        local isValid = true
-
-        local numNonExistingDoors = 0
-        if requireRoomType and layout.Type ~= rtype then
-            isValid = false
-        elseif not ignoreDoors then
-            isValid, numNonExistingDoors = StageAPI.DoLayoutDoorsMatch(layout, doors)
-        end
-
-        if isValid and requireSubtype then
-            isValid = layout.SubType == requireSubtype
-        elseif isValid and mindiff and maxdiff then
-            isValid = (layout.Difficulty >= mindiff and layout.Difficulty <= maxdiff)
-        end
-
-        if isValid and disallowIDs then
-            for _, id in ipairs(disallowIDs) do
-                if layout.StageAPIID == id then
-                    isValid = false
-                    break
-                end
+            local numNonExistingDoors = 0
+            if requireRoomType and layout.Type ~= rtype then
+                isValid = false
+            elseif not ignoreDoors then
+                isValid, numNonExistingDoors = StageAPI.DoLayoutDoorsMatch(layout, doors)
             end
-        end
 
-        local weight = layout.Weight
-        if isValid then
-            for _, callback in ipairs(callbacks) do
-                local success, ret = StageAPI.TryCallback(callback,
-                        layout, roomList, seed, shape, rtype, requireRoomType)
-                if success then
-                    if ret == false then
+            if isValid and requireSubtype then
+                isValid = layout.SubType == requireSubtype
+            elseif isValid and mindiff and maxdiff then
+                isValid = (layout.Difficulty >= mindiff and layout.Difficulty <= maxdiff)
+            end
+
+            if isValid and disallowIDs then
+                for _, id in ipairs(disallowIDs) do
+                    if layout.StageAPIID == id then
                         isValid = false
                         break
-                    elseif type(ret) == "number" then
-                        weight = ret
                     end
                 end
             end
-        end
 
-        if isValid then
-            if StageAPI.CurrentlyInitializing and not StageAPI.CurrentlyInitializing.IsExtraRoom and rtype == RoomType.ROOM_DEFAULT then
-                local originalWeight = weight
-                weight = weight * 2 ^ numNonExistingDoors
-                if shape == RoomShape.ROOMSHAPE_1x1 and numNonExistingDoors > 0 then
-                    weight = weight + math.min(originalWeight * 4, 4)
+            local weight = layout.Weight
+            if isValid then
+                for _, callback in ipairs(callbacks) do
+                    local success, ret = StageAPI.TryCallback(callback,
+                            layout, roomList, seed, shape, rtype, requireRoomType)
+                    if success then
+                        if ret == false then
+                            isValid = false
+                            break
+                        elseif type(ret) == "number" then
+                            weight = ret
+                        end
+                    end
                 end
             end
-        end
 
-        if isValid then
-            validRooms[#validRooms + 1] = {{Layout = layout, ListID = listID}, weight}
-            validRoomWeights = validRoomWeights + weight
+            if isValid then
+                if StageAPI.CurrentlyInitializing and not StageAPI.CurrentlyInitializing.IsExtraRoom and rtype == RoomType.ROOM_DEFAULT then
+                    local originalWeight = weight
+                    weight = weight * 2 ^ numNonExistingDoors
+                    if shape == RoomShape.ROOMSHAPE_1x1 and numNonExistingDoors > 0 then
+                        weight = weight + math.min(originalWeight * 4, 4)
+                    end
+                end
+            end
+
+            if isValid then
+                validRooms[#validRooms + 1] = {{Layout = layout, ListID = listID}, weight}
+                validRoomWeights = validRoomWeights + weight
+            end
         end
     end
 

--- a/scripts/stageapi/stage/customFloorGen.lua
+++ b/scripts/stageapi/stage/customFloorGen.lua
@@ -119,7 +119,9 @@ function StageAPI.LevelMap:AddRoom(levelRoom, roomData, noUpdateDoors)
         levelRoom = StageAPI.GetLevelRoom(roomData.RoomID, self.Dimension)
     end
 
-    roomData.Shape = levelRoom.Shape
+    if not roomData.Shape then
+        roomData.Shape = levelRoom and levelRoom.Shape or RoomShape.ROOMSHAPE_1x1
+    end
 
     if roomData.X and roomData.Y then
         roomData.MapSegments = StageAPI.GetRoomMapSegments(roomData.X, roomData.Y, roomData.Shape)


### PR DESCRIPTION
This PR contains multiple fixes/changes since these sorts of quit+continue bugs could only be properly tested on top of each other.

These primarily address these two bugs:

1. `attempt to index a nil value (local 'levelRoom')` (Since this error occurs during the savedata restore, it breaks a lot of things)
   <img width="1404" height="323" alt="image" src="https://github.com/user-attachments/assets/f74153ba-7da9-4252-affc-7ab5def81436" />
 2. Quitting and continuing a run can cause a StageAPI room to attempt to randomly select its base layout again, resulting in a different room being picked due to some inconsistencies in the selection after restoring the savedata.
<img width="1634" height="910" alt="20260708153844_1" src="https://github.com/user-attachments/assets/b5210301-3d58-4aab-a545-7f24f8d2195c" />
<img width="1634" height="910" alt="20260708154013_1" src="https://github.com/user-attachments/assets/b78b5d8f-400e-427a-81ac-49d36de57f80" />
<img width="1634" height="910" alt="20260708154131_1" src="https://github.com/user-attachments/assets/8032cfc3-39be-4db6-8582-5de2db91133f" />
<img width="1634" height="910" alt="20260708154142_1" src="https://github.com/user-attachments/assets/70101bad-b36f-4c97-8719-6071bf948110" />

---

Changes were broken up into seperate commits to hopefully make each change easier to follow. Refer to the "Commits" tab to view the commit messages for each one, as they contain more thorough details regarding each change.

Here is a shorter summary of each commit:

1. (1a08727 - `stage/customFloorGen.lua`) **Prevent errors in `LevelMap:AddRoom` when `levelRoom` is nil**
2. (86a251b - `core/saveSystem.lua`) **Only defer loading rooms that rely on vanilla RoomDescriptor Data**
   - Delayed loading is only necessary for rooms that rely on RoomDescriptor Data, which is not available yet on savedata load (see original commit fc0718d). This was the reason for `levelRoom` being nil in `LevelMap:AddRoom`.
3. (9111ebc - `room/roomHandler.lua`) **Update GetValidRoomsForLayout to get the "correct" (per-shape) ListID for each room when IgnoreShape is true**
   - The "list index" in relation to RoomsLists is typically their index within `RoomsList.ByShape[shape]`. However, when IgnoreShape was true and all shapes were allowed, the ListID would instead be the index within `RoomsList.All`, which is generally not useful.
   - This change by itself does not affect any existing logic, but was made to support the below change.
4. (58f1c02 - `room/levelRoom.lua`) **Populate LevelRoom.RoomsListID when randomly picking a room layout, so that the layout can be consistently restored on continue.**
   - RoomsListID is already a fully supported, persistent attribute of LevelRoom that enables the existing layout to be directly retrieved after savedata load when combined with the RoomsListName attribute. However, this value is currently only set by `StageAPI.CreateMapFromRoomsList`, and not in `StageAPI.LevelRoom:GetLayout` when a random layout is selected.
     - As a result, if IgnoreShape was set to true, the Layout would be re-picked after quit and continue, and it could choose a different room (either due to a difference in parameters, such as the value of IgnoreShape not being persisted, or a result of callbacks/code involved in the initial selection no longer running as expected).
5. (7fa9a26 - `room/levelRoom.lua`) **Persist IgnoreShape and IgnoreDoors when restoring LevelRooms**
   - These values indicate whether shapes/doors were ignored when the layout of the room is/was randomly selected from the RoomsList.
   - These values not persisting was _part_ of the reason why the random room selection after a quit+continue would pick a different room. So this change may not make much difference given the preceding changes, but since these attributes are kept on the room normally, keeping them on quit+continue should be fine too.
   
---

For testing, I've performed quit & continues (both with and without restarting the game fully) for the following:
1. Golem's Subway (Fiend Folio)
2. "Normal" rooms with StageAPI grid entities (Fiend Folio)
3. Glacier (Revelations)
   - Shrine rooms seem to error and break on continue, but the error is in Rev code and not core StageAPI. Otherwise, rooms are persisted properly.

Fall From Grace (and maybe specifically Fall From Grace with Revelations also enabled) has some separate errors/bugs on Quit & Continue that are not directly related to the ones fixed in this PR so it was not used for verification. However, it is likely that these fixes still benefit FFG, or at least clear some existing StageAPI bugs out of the way to make those easier to solve in the future.

The changes made should also mostly only affect Quit & Continue anyway, which is currently somewhat broken, so if additional issues surface (as a result of my changes or otherwise) I will be happy to fix them. But I wasn't able to identify any problems by performing various quit+continues with Golem's Subway or Glacier.