### PR TITLE
Clear custom grid entity data when a new room is loaded into the debug (goto) slot

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -968,6 +968,13 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 
     local setDefaultLevelMap
     if not StageAPI.TransitioningToExtraRoom then
+        if shared.Level:GetCurrentRoomIndex() == GridRooms.ROOM_DEBUG_IDX and shared.Room:IsFirstVisit() then
+            -- When a new room is loaded into the debug (goto) slot, clear any pre-existing custom grid data.
+            local lindex = StageAPI.GetCurrentRoomID()
+            local customGrids = StageAPI.GetTableIndexedByDimension(StageAPI.CustomGrids, true)
+            customGrids[lindex] = {}
+        end
+
         local reversedIntoExtraRoom
         if StageAPI.PreviousExtraRoomData
         and StageAPI.PreviousExtraRoomData.RoomIndex == shared.Level:GetCurrentRoomIndex() then


### PR DESCRIPTION
Using the `goto` command to access rooms with stageapi grid entities will cause the custom grids to persist and built up as different rooms are loaded, seemingly never getting cleared as each room is loaded

This change wipes custom grid data from the debug slot on "first visit" to attempt to account for this. This is not done if using the debug slot as an extra room, just in case.

<img width="1290" height="817" alt="image" src="https://github.com/user-attachments/assets/f24923ab-b446-48c7-8ad7-96de3331054e" />
