### PR TITLE
With REPENTOGON, clear entity/grid savestates from the target room before ExtraRoom transitions

### DIFF
--- a/scripts/stageapi/stage/extrarooms.lua
+++ b/scripts/stageapi/stage/extrarooms.lua
@@ -625,6 +625,25 @@ function StageAPI.ExtraRoomTransition(levelMapRoomID, direction, transitionType,
         targetRoomDesc.Flags = setFlags
     end
 
+    if REPENTOGON then
+        -- Preemptively wipe out all of the vanilla save state data for the room.
+        targetRoomDesc:GetDecoSaveState():Clear()
+        targetRoomDesc:GetEntitiesSaveState():Clear()
+        -- Grid Entity save state is a fixed size, so we have to iterate over it.
+        -- Clearing the grid data in particular is important, since it prevents
+        -- issues such as the room bounds being recalculated using the wrong walls.
+        local gridSaveState = targetRoomDesc:GetGridEntitiesSaveState()
+        for i=0, #gridSaveState-1 do
+            local gridDesc = gridSaveState:Get(i)
+            gridDesc.Initialized = false
+            gridDesc.SpawnCount = 0
+            gridDesc.State = 0
+            gridDesc.Type = 0
+            gridDesc.Variant = 0
+            gridDesc.VarData = 0
+        end
+    end
+
     shared.Level.LeaveDoor = leaveDoor
     shared.Level.EnterDoor = enterDoor
 


### PR DESCRIPTION
Ensures a clean slate for the extra room, not possible without repentogon.

The most important thing here though is the clearing of the GridEntity data, since the presence of abnormal wall grids can cause issues before StageAPI gets a chance to load the proper grid layout. For example, this can mess up the "bounds" of the room (topleft and bottomright positions, which are calculated based on wall grids), offsetting the backdrop and restricting the valid positions for certain entities (pickups, certain familiars).

This change may or may not remove the need for this logic, which may have been attempting to solve a similar issue (though ofc it can be left alone especially since its not rgon-dependant): https://github.com/Meowlala/BOIStageAPI15/blob/c94af67c3131e43462f3e2bc9582cb4abc5a87a8/scripts/stageapi/core/callbacks.lua#L910