### PR TITLE
Delete the StageAPI LevelRoom if OverrideData is present, or when a new goto room is loaded

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1469,8 +1469,16 @@ StageAPI.AddCallback("StageAPI", Callbacks.EARLY_NEW_ROOM, -1, function()
         StageAPI.LevelRooms = {}
     end
 
-    if not StageAPI.ShouldOverrideRoom() then
-        local roomDesc = shared.Level:GetCurrentRoomDesc()
+    if not StageAPI.TransitioningToExtraRoom and shared.Level:GetCurrentRoomIndex() == GridRooms.ROOM_DEBUG_IDX and shared.Room:IsFirstVisit() then
+        -- When a new room is loaded into the debug (goto) slot, delete any pre-existing LevelRoom
+        StageAPI.SetCurrentRoom(nil)
+    end
+
+    local roomDesc = shared.Level:GetCurrentRoomDesc()
+    if roomDesc.OverrideData then
+        -- Avoid overriding Greed rooms and such
+        StageAPI.SetCurrentRoom(nil)
+    elseif not StageAPI.ShouldOverrideRoom() then
         StageAPI.GenerateBaseRoom(roomDesc)
     end
 end)


### PR DESCRIPTION
This solves two issues on EARLY_NEW_ROOM:
1. Loading a room with StageAPI entities with `goto` will cause the LevelRoom to get stuck and prevent properly using `goto` to test other rooms. Here I delete any pre-existing LevelRoom right before we might create the new one (or leave the room un-LevelRoom'd)
2. If a room with StageAPI entities is used for a surprise miniboss using OverrideData (Greed/Krampus, yes Krampus does use this) StageAPI's LevelRoom will suppress the miniboss, leaving only the VS text. Here we similarly delete any existing LevelRoom (for Greed the OverrideData didn't exist on level init so we made a LevelRoom for the base layout) and prevent a new LevelRoom from being generated by GenerateBaseRoom. This also helps compatibility with God's Gambit.

This does not allow LevelRooms to be properly generated for the OverrideData miniboss rooms themselves (if one tries to use StageAPI entities in Greed/Krampus layouts they may not work properly), but I don't consider that important at this moment

<img width="876" height="418" alt="image" src="https://github.com/user-attachments/assets/b2f72727-c5e9-4f1a-a0ce-47b376297a35" />