### PR TITLE
Clear vanilla room save state only when transitioning TO extra rooms, NOT FROM THEM

### DIFF
--- a/scripts/stageapi/stage/extrarooms.lua
+++ b/scripts/stageapi/stage/extrarooms.lua
@@ -625,7 +625,7 @@ function StageAPI.ExtraRoomTransition(levelMapRoomID, direction, transitionType,
         targetRoomDesc.Flags = setFlags
     end
 
-    if REPENTOGON then
+    if REPENTOGON and StageAPI.TransitioningToExtraRoom then
         -- Preemptively wipe out all of the vanilla save state data for the room.
         targetRoomDesc:GetDecoSaveState():Clear()
         targetRoomDesc:GetEntitiesSaveState():Clear()


### PR DESCRIPTION
Fixes a bug in one of my previous PR that causes entities/grids to get wiped from a vanilla room when returning from a stageapi extra room (most easily visible by returning from Golem's Subway in a treasure room)