### PR TITLE
Use GetCurrentListIndex instead of GetCurrentRoomID when attempting to clear the vanilla goto room, etc

### DIFF
--- a/scripts/stageapi/core/callbacks.lua
+++ b/scripts/stageapi/core/callbacks.lua
@@ -1002,7 +1002,7 @@ mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
     if not StageAPI.TransitioningToExtraRoom then
         if shared.Level:GetCurrentRoomIndex() == GridRooms.ROOM_DEBUG_IDX and shared.Room:IsFirstVisit() then
             -- When a new room is loaded into the debug (goto) slot, clear any pre-existing custom grid data.
-            local lindex = StageAPI.GetCurrentRoomID()
+            local lindex = StageAPI.GetCurrentListIndex()
             local customGrids = StageAPI.GetTableIndexedByDimension(StageAPI.CustomGrids, true)
             customGrids[lindex] = {}
         end
@@ -1506,13 +1506,13 @@ StageAPI.AddCallback("StageAPI", Callbacks.EARLY_NEW_ROOM, -1, function()
 
     if not StageAPI.TransitioningToExtraRoom and shared.Level:GetCurrentRoomIndex() == GridRooms.ROOM_DEBUG_IDX and shared.Room:IsFirstVisit() then
         -- When a new room is loaded into the debug (goto) slot, delete any pre-existing LevelRoom
-        StageAPI.SetCurrentRoom(nil)
+        StageAPI.SetLevelRoom(nil, StageAPI.GetCurrentListIndex())
     end
 
     local roomDesc = shared.Level:GetCurrentRoomDesc()
     if roomDesc.OverrideData then
         -- Avoid overriding Greed rooms and such
-        StageAPI.SetCurrentRoom(nil)
+        StageAPI.SetLevelRoom(nil, StageAPI.GetCurrentListIndex())
     elseif not StageAPI.ShouldOverrideRoom() then
         StageAPI.GenerateBaseRoom(roomDesc)
     end


### PR DESCRIPTION
`StageAPI.SetCurrentRoom(nil)` will identify the current room using `StageAPI.GetCurrentRoomID()`, which will return the ExtraRoom corresponding to `StageAPI.CurrentLevelMapRoomID` if that is non-nil (otherwise, it'd return `StageAPI.GetCurrentListIndex()`)

However, this code I added previously that intends to clear/reset the goto room (and also prevent overriding of roomDesc.OverrideData rooms) seems to run before `StageAPI.CurrentLevelMapRoomID` gets updated.

As a result, using `goto` from within a StageAPI ExtraRoom will delete the ExtraRoom you came from instead of the intended vanilla room, since `StageAPI.GetCurrentRoomID()` will still point back to the ExtraRoom.

Using `StageAPI.GetCurrentListIndex()` instead seems to solve this issue, since that is what would be targeted if `StageAPI.CurrentLevelMapRoomID` was nil.

Since these bits of code are only ever intended to target vanilla rooms indices, I think that this should be fine. In practice this is doing the exact same thing it was already doing, just ignoring ExtraRooms.